### PR TITLE
fix: update agent tool name from Task to Agent for CC 2.1.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2026-03-11
+
+### Fixed
+
+- **Agent tracking** — Claude Code 2.1.72 renamed the subagent tool from `Task` to `Agent`, causing phantom agents that never complete (stuck showing growing elapsed time). Updated all tool name checks and added `toolUseResult` fallback completion signal as defense-in-depth.
+
 ## [1.0.2] - 2026-02-23
 
 ### Added
@@ -64,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Context alert thresholds** at 70%/55% — warnings appear before Claude Code's ~80% auto-compact triggers
 - **Steel blue completed checkmarks** — distinct from plan-mode green to avoid visual collision
 
+[1.0.3]: https://github.com/GregoryHo/cc-pulseline/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/GregoryHo/cc-pulseline/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/GregoryHo/cc-pulseline/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/GregoryHo/cc-pulseline/releases/tag/v1.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc-pulseline"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "criterion",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc-pulseline"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 rust-version = "1.74"
 description = "High-performance multi-line statusline for Claude Code with deep observability"

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ max_lines = 2
 ## CLI Usage
 
 ```
-cc-pulseline 1.0.2 - High-performance Claude Code statusline
+cc-pulseline 1.0.3 - High-performance Claude Code statusline
 
 USAGE:
     cc-pulseline [OPTIONS]

--- a/benches/render_pipeline.rs
+++ b/benches/render_pipeline.rs
@@ -123,7 +123,7 @@ fn large_transcript_payload() -> String {
     let transcript_path = transcript_dir.join("transcript.jsonl");
 
     let mut lines = Vec::new();
-    let tool_names = ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "Task"];
+    let tool_names = ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "Agent"];
     for i in 0..2500 {
         let name = tool_names[i % tool_names.len()];
         let id = format!("tool-{i}");

--- a/src/providers/transcript.rs
+++ b/src/providers/transcript.rs
@@ -239,6 +239,8 @@ fn apply_transcript_event(state: &mut SessionState, raw_event: &Value) {
         for block in content_blocks {
             apply_content_block(state, block, event_ts);
         }
+        // Defense-in-depth: also check toolUseResult for agent completion signal
+        check_tool_use_result_completion(state, raw_event);
         return;
     }
 
@@ -305,8 +307,8 @@ fn apply_content_block(state: &mut SessionState, block: &Value, event_ts: Option
                 .unwrap_or("unknown-id")
                 .to_string();
 
-            // Task tool → push to pending queue for agent linking
-            if name == "Task" {
+            // Agent tool → push to pending queue for agent linking
+            if name == "Agent" {
                 let input = block.get("input");
                 let description = input
                     .and_then(|i| {
@@ -314,7 +316,7 @@ fn apply_content_block(state: &mut SessionState, block: &Value, event_ts: Option
                             .or_else(|| i.get("prompt"))
                             .and_then(Value::as_str)
                     })
-                    .unwrap_or("Task")
+                    .unwrap_or("Agent")
                     .to_string();
                 let agent_type = input
                     .and_then(|i| i.get("subagent_type").and_then(Value::as_str))
@@ -382,11 +384,11 @@ fn handle_agent_progress(state: &mut SessionState, data: &Value, event_ts: Optio
         return;
     }
 
-    // Check if this is a new agent that should link to a pending Task
+    // Check if this is a new agent that should link to a pending Agent tool_use
     let is_new = !state.active_agents.iter().any(|a| a.id == agent_id);
     if is_new {
         if let Some(pending) = state.link_agent_to_pending_task(&agent_id) {
-            // Use the Task's description and type instead of agent_progress prompt
+            // Use the Agent tool's description and type instead of agent_progress prompt
             state.upsert_agent(
                 agent_id,
                 pending.description,
@@ -403,7 +405,7 @@ fn handle_agent_progress(state: &mut SessionState, data: &Value, event_ts: Optio
         return;
     }
 
-    // Standalone agent_progress (no Task): use prompt as description
+    // Standalone agent_progress (no Agent tool_use): use prompt as description
     let description = data
         .get("description")
         .or_else(|| data.get("prompt"))
@@ -512,7 +514,7 @@ fn extract_target(name: &str, block: &Value) -> Option<String> {
             let query = input.get("query").and_then(Value::as_str)?;
             Some(truncate_str(query, 30))
         }
-        "Task" => None, // Task → agent, not tool
+        "Agent" => None, // Agent → subagent, not tool
         _ => {
             // Generic fallback: try file_path → command → pattern
             input
@@ -582,7 +584,7 @@ fn apply_flat_event(state: &mut SessionState, raw_event: &Value, event_ts: Optio
     match event_type.as_deref() {
         Some("tool_use") => handle_flat_tool_use(state, event, raw_event, event_ts),
         Some("tool_result") => handle_flat_tool_result(state, event, raw_event),
-        Some("Task") => handle_task_event(state, event, event_ts),
+        Some("Agent") => handle_task_event(state, event, event_ts),
         Some("TaskCreate") => {
             dispatch_task_create(state, event, Some(raw_event));
         }
@@ -607,7 +609,7 @@ fn handle_flat_tool_use(
         .unwrap_or_else(|| "unknown".to_string());
 
     match name.as_str() {
-        "Task" => {
+        "Agent" => {
             handle_task_from_tool_use(state, event, raw_event, event_ts);
         }
         "TaskCreate" => {
@@ -674,7 +676,7 @@ fn handle_task_from_tool_use(
                 ],
             )
         })
-        .unwrap_or_else(|| "Task".to_string());
+        .unwrap_or_else(|| "Agent".to_string());
 
     state.upsert_agent(id, summary, None, event_ts, None);
 }
@@ -690,7 +692,7 @@ fn handle_event_by_name(
     };
 
     match name.as_str() {
-        "Task" => handle_task_from_tool_use(state, event, raw_event, event_ts),
+        "Agent" => handle_task_from_tool_use(state, event, raw_event, event_ts),
         "TaskCreate" => {
             dispatch_task_create(state, event, Some(raw_event));
         }
@@ -701,6 +703,23 @@ fn handle_event_by_name(
             dispatch_todo_write(state, event, Some(raw_event));
         }
         _ => {}
+    }
+}
+
+/// Check `toolUseResult` for agent completion (defense-in-depth for tool_result path).
+///
+/// Claude Code appends a top-level `toolUseResult` object on agent completion events,
+/// containing `{ status, agentId, content, ... }`. This is redundant with the `tool_result`
+/// content block processed by Path 1, but provides a fallback if the link-based resolution
+/// in `complete_tool_result()` fails (e.g., ID mismatch). `remove_agent()` is idempotent.
+fn check_tool_use_result_completion(state: &mut SessionState, raw_event: &Value) {
+    if let Some(tur) = raw_event.get("toolUseResult") {
+        if let Some(agent_id) = tur.get("agentId").and_then(Value::as_str) {
+            let status = tur.get("status").and_then(Value::as_str).unwrap_or("");
+            if is_terminal_status(status) {
+                state.remove_agent(agent_id);
+            }
+        }
     }
 }
 

--- a/src/render/layout.rs
+++ b/src/render/layout.rs
@@ -258,7 +258,7 @@ fn format_todo_lines(
 /// With agent_type: `A:Explore: Investigate logic (2m)`
 /// Without:         `A:Investigate logic (2m)`
 ///
-/// The description field comes from the Task tool's `description` (3-5 word short summary)
+/// The description field comes from the Agent tool's `description` (3-5 word short summary)
 /// when available, falling back to `prompt` (full text). We truncate to first line,
 /// max ACTIVITY_TEXT_MAX_CHARS to keep activity lines compact.
 fn format_agent_line(agent: &AgentSummary, config: &RenderConfig, tier: &EmphasisTier) -> String {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -27,7 +27,7 @@ pub struct SessionState {
     pub completed_agents: Vec<AgentSummary>,
     pub completed_tool_counts: HashMap<String, u32>,
     pub todo: Option<TodoSummary>,
-    // Agent linking: Task tool_use → agent_progress ID linking
+    // Agent linking: Agent tool_use → agent_progress ID linking
     pub pending_tasks: Vec<PendingTask>,
     pub task_agent_links: HashMap<String, String>, // tool_use_id → agentId
     // Todo tracking: TaskCreate/TaskUpdate stateful accumulation
@@ -281,7 +281,7 @@ impl SessionState {
         Some(self.pending_tasks.remove(pos))
     }
 
-    /// Check if an agent was linked from a Task tool_use.
+    /// Check if an agent was linked from an Agent tool_use.
     pub fn is_task_linked_agent(&self, agent_id: &str) -> bool {
         self.task_agent_links.values().any(|id| id == agent_id)
     }

--- a/tests/activity_pipeline.rs
+++ b/tests/activity_pipeline.rs
@@ -552,7 +552,7 @@ fn tracks_task_tool_as_agent() {
         ..RenderConfig::default()
     };
 
-    // Event 0: Task tool_use → pushes to pending queue, no agent visible yet
+    // Event 0: Agent tool_use → pushes to pending queue, no agent visible yet
     append_line(&transcript, events[0]);
     let lines = runner
         .run_from_str(
@@ -562,11 +562,11 @@ fn tracks_task_tool_as_agent() {
         .expect("render should succeed");
     let joined = lines.join("\n");
     assert!(
-        !joined.contains("T:Task"),
-        "Task should not appear as a tool line: got {joined}"
+        !joined.contains("T:Agent"),
+        "Agent should not appear as a tool line: got {joined}"
     );
 
-    // Event 1: agent_progress → links to pending Task, creates agent with Task's description
+    // Event 1: agent_progress → links to pending Agent, creates agent with Agent's description
     append_line(&transcript, events[1]);
     let lines = runner
         .run_from_str(
@@ -835,8 +835,8 @@ fn task_tool_defaults_missing_fields() {
         .expect("render should succeed");
     let joined = lines.join("\n");
     assert!(
-        !joined.contains("T:Task"),
-        "Task should never appear as tool line: got {joined}"
+        !joined.contains("T:Agent"),
+        "Agent should never appear as tool line: got {joined}"
     );
 
     // Event 1: tool_result → drains pending, creates+completes agent inline with [done]
@@ -846,8 +846,8 @@ fn task_tool_defaults_missing_fields() {
         .expect("render should succeed");
     let joined = lines.join("\n");
     assert!(
-        joined.contains("A:Task") && joined.contains("[done]"),
-        "tool_result should drain pending and show default Task agent as done: got {joined}"
+        joined.contains("A:Agent") && joined.contains("[done]"),
+        "tool_result should drain pending and show default Agent as done: got {joined}"
     );
 }
 
@@ -867,7 +867,7 @@ fn links_agent_progress_to_task_tool_use() {
         ..RenderConfig::default()
     };
 
-    // Event 0: Task tool_use → pending queue, no agent visible
+    // Event 0: Agent tool_use → pending queue, no agent visible
     append_line(&transcript, events[0]);
     let lines = runner
         .run_from_str(
@@ -878,7 +878,7 @@ fn links_agent_progress_to_task_tool_use() {
     let joined = lines.join("\n");
     assert!(
         !joined.contains("A:"),
-        "Task tool_use should not create visible agent yet: got {joined}"
+        "Agent tool_use should not create visible agent yet: got {joined}"
     );
 
     // Event 1: first agent_progress → links to pending, creates single agent
@@ -892,7 +892,7 @@ fn links_agent_progress_to_task_tool_use() {
     let joined = lines.join("\n");
     assert!(
         joined.contains("Explore agent tracking code"),
-        "linked agent should use Task's description, not prompt: got {joined}"
+        "linked agent should use Agent's description, not prompt: got {joined}"
     );
     assert!(
         joined.contains("A:Explore"),
@@ -947,7 +947,7 @@ fn links_concurrent_agents_fifo() {
         ..RenderConfig::default()
     };
 
-    // Event 0: Two Task tool_uses in one message → two pending tasks
+    // Event 0: Two Agent tool_uses in one message → two pending tasks
     append_line(&transcript, events[0]);
     let lines = runner
         .run_from_str(
@@ -973,11 +973,11 @@ fn links_concurrent_agents_fifo() {
     let joined = lines.join("\n");
     assert!(
         joined.contains("A:Explore: Search for config files"),
-        "first agent should get first Task's description: got {joined}"
+        "first agent should get first Agent's description: got {joined}"
     );
     assert!(
         joined.contains("A:Bash: Run test suite"),
-        "second agent should get second Task's description: got {joined}"
+        "second agent should get second Agent's description: got {joined}"
     );
     let agent_lines: Vec<&String> = lines.iter().filter(|l| l.starts_with("A:")).collect();
     assert_eq!(
@@ -1030,7 +1030,7 @@ fn standalone_agent_progress_without_task() {
         ..RenderConfig::default()
     };
 
-    // agent_progress with no preceding Task tool_use → standalone agent
+    // agent_progress with no preceding Agent tool_use → standalone agent
     append_line(
         &transcript,
         r#"{"type":"progress","data":{"type":"agent_progress","agentId":"standalone-1","prompt":"Investigate the bug","agentType":"Explore"}}"#,
@@ -1078,10 +1078,10 @@ fn task_completes_without_agent_progress() {
         ..RenderConfig::default()
     };
 
-    // Task tool_use → pending queue
+    // Agent tool_use → pending queue
     append_line(
         &transcript,
-        r#"{"timestamp":"2026-01-18T10:50:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_fast","name":"Task","input":{"description":"Quick lookup","subagent_type":"Explore"}}]}}"#,
+        r#"{"timestamp":"2026-01-18T10:50:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_fast","name":"Agent","input":{"description":"Quick lookup","subagent_type":"Explore"}}]}}"#,
     );
 
     let lines = runner

--- a/tests/adaptive_performance.rs
+++ b/tests/adaptive_performance.rs
@@ -61,7 +61,7 @@ fn degrades_layout_for_narrow_terminal_widths() {
     );
     append_line(
         &transcript,
-        r#"{"type":"Task","task_id":"agent-1","name":"Planner","status":"running"}"#,
+        r#"{"type":"Agent","task_id":"agent-1","name":"Planner","status":"running"}"#,
     );
     append_line(
         &transcript,

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -72,7 +72,7 @@ fn version_flag_shows_version() {
         stdout.contains("cc-pulseline"),
         "should contain binary name"
     );
-    assert!(stdout.contains("1.0.2"), "should contain version number");
+    assert!(stdout.contains("1.0.3"), "should contain version number");
 }
 
 #[test]
@@ -85,7 +85,7 @@ fn short_version_flag_works() {
     assert!(output.status.success(), "should exit 0");
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(
-        stdout.contains("cc-pulseline 1.0.2"),
+        stdout.contains("cc-pulseline 1.0.3"),
         "should show name and version"
     );
 }

--- a/tests/fixtures/transcript_agent_flow.jsonl
+++ b/tests/fixtures/transcript_agent_flow.jsonl
@@ -1,4 +1,4 @@
-{"timestamp":"2026-01-18T10:50:00.000Z","type":"Task","task_id":"agent-1","name":"Indexer","status":"running"}
-{"timestamp":"2026-01-18T10:51:00.000Z","type":"Task","task_id":"agent-2","name":"Planner","status":"running"}
-{"timestamp":"2026-01-18T10:52:00.000Z","type":"Task","task_id":"agent-3","name":"Reviewer","status":"running"}
-{"timestamp":"2026-01-18T10:55:00.000Z","type":"Task","task_id":"agent-2","name":"Planner","status":"completed"}
+{"timestamp":"2026-01-18T10:50:00.000Z","type":"Agent","task_id":"agent-1","name":"Indexer","status":"running"}
+{"timestamp":"2026-01-18T10:51:00.000Z","type":"Agent","task_id":"agent-2","name":"Planner","status":"running"}
+{"timestamp":"2026-01-18T10:52:00.000Z","type":"Agent","task_id":"agent-3","name":"Reviewer","status":"running"}
+{"timestamp":"2026-01-18T10:55:00.000Z","type":"Agent","task_id":"agent-2","name":"Planner","status":"completed"}

--- a/tests/fixtures/transcript_nested_task_agent.jsonl
+++ b/tests/fixtures/transcript_nested_task_agent.jsonl
@@ -1,3 +1,3 @@
-{"timestamp":"2026-01-18T10:50:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"task-001","name":"Task","input":{"description":"Refactor parser","subagent_type":"Architect"}}]}}
+{"timestamp":"2026-01-18T10:50:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"task-001","name":"Agent","input":{"description":"Refactor parser","subagent_type":"Architect"}}]}}
 {"timestamp":"2026-01-18T10:50:01.000Z","type":"progress","data":{"type":"agent_progress","agentId":"a-linked-001","prompt":"I will refactor the parser module to improve clarity"}}
 {"timestamp":"2026-01-18T10:53:00.000Z","content":[{"type":"tool_result","tool_use_id":"task-001"}]}

--- a/tests/fixtures/transcript_nested_task_no_fields.jsonl
+++ b/tests/fixtures/transcript_nested_task_no_fields.jsonl
@@ -1,2 +1,2 @@
-{"timestamp":"2026-01-18T10:50:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"task-bare","name":"Task","input":{}}]}}
+{"timestamp":"2026-01-18T10:50:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"task-bare","name":"Agent","input":{}}]}}
 {"timestamp":"2026-01-18T10:53:00.000Z","content":[{"type":"tool_result","tool_use_id":"task-bare"}]}

--- a/tests/fixtures/transcript_real_agent_lifecycle.jsonl
+++ b/tests/fixtures/transcript_real_agent_lifecycle.jsonl
@@ -1,4 +1,4 @@
-{"timestamp":"2026-01-18T10:50:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01G5abc","name":"Task","input":{"description":"Explore agent tracking code","subagent_type":"Explore","model":"haiku"}}]}}
+{"timestamp":"2026-01-18T10:50:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01G5abc","name":"Agent","input":{"description":"Explore agent tracking code","subagent_type":"Explore","model":"haiku"}}]}}
 {"timestamp":"2026-01-18T10:50:01.000Z","type":"progress","data":{"type":"agent_progress","agentId":"a2016bc","prompt":"Explore the agent tracking code in the codebase and understand how agents are linked"}}
 {"timestamp":"2026-01-18T10:50:10.000Z","type":"progress","data":{"type":"agent_progress","agentId":"a2016bc","prompt":"Still investigating the agent tracking code, found relevant files"}}
 {"timestamp":"2026-01-18T10:53:00.000Z","content":[{"type":"tool_result","tool_use_id":"toolu_01G5abc"}]}

--- a/tests/fixtures/transcript_real_concurrent_agents.jsonl
+++ b/tests/fixtures/transcript_real_concurrent_agents.jsonl
@@ -1,4 +1,4 @@
-{"timestamp":"2026-01-18T10:50:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_task1","name":"Task","input":{"description":"Search for config files","subagent_type":"Explore"}},{"type":"tool_use","id":"toolu_task2","name":"Task","input":{"description":"Run test suite","subagent_type":"Bash"}}]}}
+{"timestamp":"2026-01-18T10:50:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_task1","name":"Agent","input":{"description":"Search for config files","subagent_type":"Explore"}},{"type":"tool_use","id":"toolu_task2","name":"Agent","input":{"description":"Run test suite","subagent_type":"Bash"}}]}}
 {"timestamp":"2026-01-18T10:50:01.000Z","type":"progress","data":{"type":"agent_progress","agentId":"a111","prompt":"Searching for config files across the codebase"}}
 {"timestamp":"2026-01-18T10:50:02.000Z","type":"progress","data":{"type":"agent_progress","agentId":"a222","prompt":"Running the full test suite to check for failures"}}
 {"timestamp":"2026-01-18T10:51:00.000Z","content":[{"type":"tool_result","tool_use_id":"toolu_task1"}]}

--- a/tests/fixtures/transcript_tool_agent_todo.jsonl
+++ b/tests/fixtures/transcript_tool_agent_todo.jsonl
@@ -1,4 +1,4 @@
 {"type":"tool_use","id":"tool-1","name":"Read","input":{"path":"src/lib.rs"}}
 {"type":"tool_result","tool_use_id":"tool-1","status":"ok"}
-{"type":"tool_use","id":"task-1","name":"Task","input":{"description":"Investigate parser edge case"}}
+{"type":"tool_use","id":"task-1","name":"Agent","input":{"description":"Investigate parser edge case"}}
 {"type":"tool_use","id":"todo-1","name":"TodoWrite","input":{"todos":[{"content":"ship stage 3","status":"in_progress"},{"content":"cleanup docs","status":"completed"},{"content":"add snapshots","status":"pending"}]}}

--- a/tests/session_cache.rs
+++ b/tests/session_cache.rs
@@ -371,12 +371,12 @@ fn model_tag_appears_for_task_with_model() {
         ..RenderConfig::default()
     };
 
-    // Task tool_use with model field → goes to pending queue
+    // Agent tool_use with model field → goes to pending queue
     append_line(
         &transcript,
-        r#"{"message":{"role":"assistant","content":[{"type":"tool_use","id":"task-m1","name":"Task","input":{"description":"Search auth code","subagent_type":"Explore","model":"haiku"}}]},"timestamp":"2026-01-18T11:00:00.000Z"}"#,
+        r#"{"message":{"role":"assistant","content":[{"type":"tool_use","id":"task-m1","name":"Agent","input":{"description":"Search auth code","subagent_type":"Explore","model":"haiku"}}]},"timestamp":"2026-01-18T11:00:00.000Z"}"#,
     );
-    // agent_progress → links to pending task, inherits model from Task
+    // agent_progress → links to pending task, inherits model from Agent
     append_line(
         &transcript,
         r#"{"type":"progress","data":{"type":"agent_progress","agentId":"a-model-1","prompt":"Searching auth code in the codebase"},"timestamp":"2026-01-18T11:00:01.000Z"}"#,


### PR DESCRIPTION
## Summary

- Claude Code 2.1.72 renamed the subagent tool from `Task` to `Agent`, causing phantom agents that never complete (stuck showing growing elapsed time)
- Updated all tool name checks (`"Task"` → `"Agent"`) in transcript parsing, flat event dispatch, and target extraction
- Added `toolUseResult` fallback completion signal as defense-in-depth for agent lifecycle tracking
- Bumped version to 1.0.3

## Test plan

- [x] All existing tests updated and passing (`cargo test`)
- [x] Transcript fixtures updated to use `"Agent"` tool name
- [x] Version bumped in Cargo.toml, Cargo.lock, README, CLI flags test, and CHANGELOG