### PR TITLE
feat: tool tracking improvements for v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2026-03-13
+
+### Added
+
+- **Noise tool filtering** — 9 internal Claude Code tools (EnterPlanMode, ExitPlanMode, EnterWorktree, ExitWorktree, TaskGet, TaskList, TaskOutput, TaskStop, ToolSearch) excluded from tool tracking, keeping completed counts and recent tools focused on user-visible tools
+- **Hybrid tool scoring** — Completed tools ranked by `count + recency_bonus` where the recency bonus decays linearly over 2 minutes — recently used tools float up even with low total counts
+- **Expanded target extraction** — Skill (skill name), AskUserQuestion (question text), SendMessage (recipient), LSP (command), WebFetch (URL), WebSearch (query), NotebookEdit (file path), plus generic fallback chain (`file_path` → `command` → `pattern`) for unknown tools
+- **Multi-line completed tools** — `tools_per_line` config (default 6) wraps completed tool counts across multiple lines
+
+### Changed
+
+- **Completed tool sorting** — Replaced count-only sorting (`top_completed_tools()`) with hybrid scoring (`scored_completed_tools()`)
+- **Cache schema** — `completed_tool_counts` internal format changed to track last completion timestamp; old cache files silently discarded and regenerated
+
 ## [1.0.3] - 2026-03-11
 
 ### Fixed
@@ -70,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Context alert thresholds** at 70%/55% — warnings appear before Claude Code's ~80% auto-compact triggers
 - **Steel blue completed checkmarks** — distinct from plan-mode green to avoid visual collision
 
+[1.0.4]: https://github.com/GregoryHo/cc-pulseline/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/GregoryHo/cc-pulseline/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/GregoryHo/cc-pulseline/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/GregoryHo/cc-pulseline/compare/v1.0.0...v1.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc-pulseline"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "criterion",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc-pulseline"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 rust-version = "1.74"
 description = "High-performance multi-line statusline for Claude Code with deep observability"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A multi-line statusline for [Claude Code](https://docs.anthropic.com/en/docs/cla
 
 ![Cost alert](docs/assets/cost-alert.png)
 
-**Tool Tracking** — Running tools + completed counts on L4
+**Tool Tracking** — Running tools with targets + completed counts (noise-filtered, multi-line wrapping)
 
 ![Tool tracking](docs/assets/tool-tracking.png)
 
@@ -134,6 +134,7 @@ show_cost = true
 enabled = true
 max_lines = 2           # max running tools shown
 max_completed = 4       # max completed tool counts
+tools_per_line = 6      # completed tools per line before wrapping
 
 [segments.agents]
 enabled = true
@@ -147,7 +148,7 @@ max_lines = 2
 ## CLI Usage
 
 ```
-cc-pulseline 1.0.3 - High-performance Claude Code statusline
+cc-pulseline 1.0.4 - High-performance Claude Code statusline
 
 USAGE:
     cc-pulseline [OPTIONS]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,7 +89,8 @@ Each provider has a real implementation and a `Stub*` variant for testing:
 
 - Transcript file offset (for incremental parsing)
 - Active tools, recent tools (persist after completion for display), agents, and todo lists
-- Completed tool/agent counts
+- Completed tool counts with last-used timestamps (hybrid scoring: count + recency bonus)
+- Completed agents (FIFO buffer, max 10)
 - Cached env/git snapshots (with TTL)
 - Cached L3 metrics (for flicker prevention)
 - Output speed tracking (delta-based tok/s, holds last known)
@@ -111,7 +112,7 @@ Persists `SessionState` across process invocations:
 
 - Glyph mode (Nerd Font icons vs ASCII)
 - Color enable/disable
-- Line caps (`max_tool_lines`, `max_agent_lines`)
+- Line caps (`max_tool_lines`, `max_agent_lines`, `tools_per_line`)
 - Transcript windowing and poll throttle
 - Terminal width and width degradation strategy order
 - Segment toggles for each line
@@ -196,7 +197,7 @@ Backward compatibility with older transcript formats and test fixtures:
 - **L2**: `1 CLAUDE.md | 2 rules | 3 memories | 1 hooks | 2 MCPs | 2 skills | 1h`
 - **L3**: `CTX:43% (86.0k/200.0k) | TOK I:10k O:20k C:30k/40k | ↗42/s | $3.50 ($3.50/h)`
 - **Quota**: `Q:Pro 5h: 75% (resets 2h 0m)`
-- **L4a**: `✓ Read ×12 | ✓ Bash ×8 | ✓ Edit ×5` (completed counts)
+- **L4a**: `✓ Read ×12 | ✓ Bash ×8 | ✓ Edit ×5` (completed counts, wraps at `tools_per_line`)
 - **L4b**: `T:Read: .../main.rs | T:Bash: cargo test` (recent/running tools)
 - **L5+**: `A:Explore [haiku]: Investigate logic (2m)`
 

--- a/docs/metrics-reference.md
+++ b/docs/metrics-reference.md
@@ -254,6 +254,12 @@ Dedicated line for accumulated completion counts — stable, grows over the sess
 
 Capped by `max_completed_tools` config value.
 
+**Noise filtering**: 9 internal Claude Code tools are excluded from tracking: EnterPlanMode, ExitPlanMode, EnterWorktree, ExitWorktree, TaskGet, TaskList, TaskOutput, TaskStop, ToolSearch.
+
+**Hybrid scoring**: Tools ranked by `score = count + recency_bonus` where `recency_bonus = 3.0 × max(0, 1 − age_ms / 120,000)`. Recently used tools (within 2 minutes) get up to 3 bonus points, floating up even with low counts. After decay, pure count dominates. Ties broken alphabetically.
+
+**Multi-line wrapping**: Completed tools wrap at `tools_per_line` (default: 6) using chunked rendering.
+
 ### Running/Recent Tools (L4b)
 
 Dedicated line for running and recently used tools with targets — volatile, changes with each tool use.
@@ -268,10 +274,16 @@ Dedicated line for running and recently used tools with targets — volatile, ch
 
 | Tool Name | Target Field | Example |
 |-----------|-------------|---------|
-| Read, Write, Edit | `input.file_path` | `T:Read: .../main.rs` |
+| Read, Write, Edit, NotebookEdit | `input.file_path` | `T:Read: .../main.rs` |
 | Bash | `input.command` | `T:Bash: cargo test` |
 | Glob, Grep | `input.pattern` | `T:Grep: TODO` |
-| Other | (none) | `T:WebSearch` |
+| WebFetch | `input.url` | `T:WebFetch: https://example...` |
+| WebSearch | `input.query` | `T:WebSearch: rust async` |
+| Skill | `input.skill` | `T:Skill: commit` |
+| AskUserQuestion | `input.questions[0].question` | `T:AskUserQuestion: Which dat...` |
+| SendMessage | `input.to` | `T:SendMessage: code-reviewer` |
+| LSP | `input.command` | `T:LSP: getDefinition` |
+| Other (generic) | `file_path` → `command` → `pattern` | Fallback chain |
 
 Both lines are controlled by a single `show_tools` toggle. Display capped by `max_tool_lines`.
 
@@ -368,6 +380,7 @@ Line 3 metrics (context, tokens, cost) use a special merge strategy:
 - **Write**: Atomic (write `.tmp` file, then rename)
 - **Read**: On first encounter of a session key only
 - **Errors**: All load/save errors silently ignored (never crashes the statusline)
+- **Schema evolution**: Cache uses `#[serde(default)]`; schema changes (e.g., v1.0.4 `completed_tool_counts` format change) cause old files to silently fail deserialization and regenerate fresh
 
 ### Layer 6: Quota Cache
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,9 @@ fn default_max_lines() -> usize {
 fn default_max_completed() -> usize {
     4
 }
+fn default_tools_per_line() -> usize {
+    6
+}
 
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct PulselineConfig {
@@ -171,6 +174,8 @@ pub struct ToolSegmentConfig {
     pub max_lines: usize,
     #[serde(default = "default_max_completed")]
     pub max_completed: usize,
+    #[serde(default = "default_tools_per_line")]
+    pub tools_per_line: usize,
 }
 
 impl Default for ToolSegmentConfig {
@@ -179,6 +184,7 @@ impl Default for ToolSegmentConfig {
             enabled: true,
             max_lines: 2,
             max_completed: 4,
+            tools_per_line: 6,
         }
     }
 }
@@ -261,6 +267,7 @@ show_seven_day = false
 enabled = true
 max_lines = 2           # max running tools shown
 max_completed = 4       # max completed tool counts
+tools_per_line = 6      # completed tools per line
 
 [segments.agents]
 enabled = true
@@ -338,6 +345,7 @@ pub struct ProjectToolOverride {
     pub enabled: Option<bool>,
     pub max_lines: Option<usize>,
     pub max_completed: Option<usize>,
+    pub tools_per_line: Option<usize>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -463,6 +471,9 @@ pub fn merge_configs(
             if let Some(v) = tools.max_completed {
                 user.segments.tools.max_completed = v;
             }
+            if let Some(v) = tools.tools_per_line {
+                user.segments.tools.tools_per_line = v;
+            }
         }
         if let Some(agents) = &segments.agents {
             if let Some(v) = agents.enabled {
@@ -554,6 +565,7 @@ pub fn default_project_config_toml() -> &'static str {
 # enabled = true
 # max_lines = 2
 # max_completed = 4
+# tools_per_line = 6
 
 # [segments.agents]
 # enabled = true
@@ -618,6 +630,7 @@ pub struct RenderConfig {
     // Activity segment toggles + limits
     pub max_tool_lines: usize,
     pub max_completed_tools: usize,
+    pub tools_per_line: usize,
     pub max_agent_lines: usize,
     pub max_todo_lines: usize,
     pub show_tools: bool,
@@ -657,6 +670,7 @@ impl Default for RenderConfig {
             show_quota_seven_day: false,
             max_tool_lines: 2,
             max_completed_tools: 4,
+            tools_per_line: 6,
             max_agent_lines: 2,
             max_todo_lines: 2,
             show_tools: true,
@@ -723,6 +737,7 @@ pub fn build_render_config(pulseline: &PulselineConfig) -> RenderConfig {
         // Activity
         max_tool_lines: pulseline.segments.tools.max_lines,
         max_completed_tools: pulseline.segments.tools.max_completed,
+        tools_per_line: pulseline.segments.tools.tools_per_line,
         max_agent_lines: pulseline.segments.agents.max_lines,
         max_todo_lines: pulseline.segments.todo.max_lines,
         show_tools: pulseline.segments.tools.enabled,

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,6 +195,7 @@ fn print_config(project_root: Option<&str>) {
     println!("enabled = {}", config.segments.tools.enabled);
     println!("max_lines = {}", config.segments.tools.max_lines);
     println!("max_completed = {}", config.segments.tools.max_completed);
+    println!("tools_per_line = {}", config.segments.tools.tools_per_line);
     println!();
     println!("[segments.agents]");
     println!("enabled = {}", config.segments.agents.enabled);

--- a/src/providers/transcript.rs
+++ b/src/providers/transcript.rs
@@ -370,7 +370,7 @@ fn apply_content_block(state: &mut SessionState, block: &Value, event_ts: Option
         }
         "tool_result" => {
             if let Some(id) = block.get("tool_use_id").and_then(Value::as_str) {
-                complete_tool_result(state, id);
+                complete_tool_result(state, id, event_ts);
             }
 
             // Check for todo data in result
@@ -487,8 +487,8 @@ fn dispatch_todo_write(state: &mut SessionState, event: &Value, fallback: Option
 }
 
 /// Complete a tool_result by resolving agent links: linked agent, pending task, or plain removal.
-fn complete_tool_result(state: &mut SessionState, tool_use_id: &str) {
-    state.remove_tool(tool_use_id);
+fn complete_tool_result(state: &mut SessionState, tool_use_id: &str, event_ts: Option<u64>) {
+    state.remove_tool(tool_use_id, event_ts);
     if let Some(linked_agent) = state.resolve_task_agent(tool_use_id) {
         state.remove_agent(&linked_agent);
     } else if let Some(pending) = state.drain_pending_task(tool_use_id) {
@@ -619,7 +619,7 @@ fn apply_flat_event(state: &mut SessionState, raw_event: &Value, event_ts: Optio
 
     match event_type.as_deref() {
         Some("tool_use") => handle_flat_tool_use(state, event, raw_event, event_ts),
-        Some("tool_result") => handle_flat_tool_result(state, event, raw_event),
+        Some("tool_result") => handle_flat_tool_result(state, event, raw_event, event_ts),
         Some("Agent") => handle_task_event(state, event, event_ts),
         Some("TaskCreate") => {
             dispatch_task_create(state, event, Some(raw_event));
@@ -669,11 +669,16 @@ fn handle_flat_tool_use(
     }
 }
 
-fn handle_flat_tool_result(state: &mut SessionState, event: &Value, raw_event: &Value) {
+fn handle_flat_tool_result(
+    state: &mut SessionState,
+    event: &Value,
+    raw_event: &Value,
+    event_ts: Option<u64>,
+) {
     if let Some(id) = find_string(event, &["tool_use_id", "id", "tool_call_id"])
         .or_else(|| find_string(raw_event, &["tool_use_id", "id", "tool_call_id"]))
     {
-        complete_tool_result(state, &id);
+        complete_tool_result(state, &id, event_ts);
     }
 
     if let Some(todo) = extract_todo_summary(event).or_else(|| extract_todo_summary(raw_event)) {

--- a/src/providers/transcript.rs
+++ b/src/providers/transcript.rs
@@ -346,6 +346,22 @@ fn apply_content_block(state: &mut SessionState, block: &Value, event_ts: Option
                 return;
             }
 
+            // Internal CC tools — skip from tool tracking
+            const NOISE_TOOLS: &[&str] = &[
+                "EnterPlanMode",
+                "ExitPlanMode",
+                "EnterWorktree",
+                "ExitWorktree",
+                "TaskGet",
+                "TaskList",
+                "TaskOutput",
+                "TaskStop",
+                "ToolSearch",
+            ];
+            if NOISE_TOOLS.contains(&name.as_str()) {
+                return;
+            }
+
             // Extract target from input
             let target = extract_target(&name, block);
             state.upsert_tool(id, name, target);
@@ -514,6 +530,24 @@ fn extract_target(name: &str, block: &Value) -> Option<String> {
             let query = input.get("query").and_then(Value::as_str)?;
             Some(truncate_str(query, 30))
         }
+        "Skill" => {
+            let skill = input.get("skill").and_then(Value::as_str)?;
+            Some(truncate_str(skill, 20))
+        }
+        "AskUserQuestion" => input
+            .get("questions")
+            .and_then(Value::as_array)
+            .and_then(|qs| qs.first())
+            .and_then(|q| q.get("question").and_then(Value::as_str))
+            .map(|q| truncate_str(q, 30)),
+        "SendMessage" => input
+            .get("to")
+            .and_then(Value::as_str)
+            .map(|to| truncate_str(to, 20)),
+        "LSP" => input
+            .get("command")
+            .and_then(Value::as_str)
+            .map(|c| truncate_str(c, 20)),
         "Agent" => None, // Agent → subagent, not tool
         _ => {
             // Generic fallback: try file_path → command → pattern
@@ -733,7 +767,7 @@ fn is_terminal_status(status: &str) -> bool {
 fn snapshot_from_state(state: &SessionState, config: &RenderConfig) -> TranscriptSnapshot {
     TranscriptSnapshot {
         tools: state.capped_tools(config.max_tool_lines),
-        completed_counts: state.top_completed_tools(config.max_completed_tools),
+        completed_counts: state.scored_completed_tools(config.max_completed_tools),
         agents: state.agents_for_display(config.max_agent_lines),
         todo: state.todo.clone(),
     }

--- a/src/providers/transcript.rs
+++ b/src/providers/transcript.rs
@@ -287,6 +287,20 @@ fn extract_content_blocks(raw_event: &Value) -> Option<Vec<&Value>> {
 }
 
 /// Process a single content block from a message's content[] array.
+/// Internal Claude Code tools excluded from tool tracking.
+/// Referenced by both Path 1 (nested content) and Path 3 (flat fallback).
+const NOISE_TOOLS: &[&str] = &[
+    "EnterPlanMode",
+    "ExitPlanMode",
+    "EnterWorktree",
+    "ExitWorktree",
+    "TaskGet",
+    "TaskList",
+    "TaskOutput",
+    "TaskStop",
+    "ToolSearch",
+];
+
 fn apply_content_block(state: &mut SessionState, block: &Value, event_ts: Option<u64>) {
     let block_type = match block.get("type").and_then(Value::as_str) {
         Some(t) => t,
@@ -346,18 +360,6 @@ fn apply_content_block(state: &mut SessionState, block: &Value, event_ts: Option
                 return;
             }
 
-            // Internal CC tools — skip from tool tracking
-            const NOISE_TOOLS: &[&str] = &[
-                "EnterPlanMode",
-                "ExitPlanMode",
-                "EnterWorktree",
-                "ExitWorktree",
-                "TaskGet",
-                "TaskList",
-                "TaskOutput",
-                "TaskStop",
-                "ToolSearch",
-            ];
             if NOISE_TOOLS.contains(&name.as_str()) {
                 return;
             }
@@ -656,6 +658,9 @@ fn handle_flat_tool_use(
             dispatch_todo_write(state, event, Some(raw_event));
         }
         _ => {
+            if NOISE_TOOLS.contains(&name.as_str()) {
+                return;
+            }
             let id = find_string(event, &["id", "tool_use_id", "tool_call_id"])
                 .or_else(|| find_string(raw_event, &["id", "tool_use_id", "tool_call_id"]))
                 .unwrap_or_else(|| format!("{name}-active"));

--- a/src/render/layout.rs
+++ b/src/render/layout.rs
@@ -46,10 +46,10 @@ pub fn render_frame(frame: &RenderFrame, config: &RenderConfig) -> Vec<String> {
         }
     }
 
-    // Tool lines: completed counts (stable) then recent tools (volatile)
+    // Tool lines: completed counts (stable, multi-line) then recent tools (volatile)
     if config.show_tools {
         if !frame.completed_tools.is_empty() {
-            lines.push(format_completed_tool_line(frame, config, &tier));
+            lines.extend(format_completed_tool_lines(frame, config, &tier));
         }
         if !frame.tools.is_empty() {
             lines.push(format_recent_tool_line(frame, config, &tier));
@@ -80,28 +80,34 @@ pub fn render_frame(frame: &RenderFrame, config: &RenderConfig) -> Vec<String> {
     lines
 }
 
-/// Format the completed tool counts line.
-/// Example: `✓ Read ×12 | ✓ Bash ×8 | ✓ Edit ×5`
-fn format_completed_tool_line(
+/// Format completed tool counts across multiple lines.
+/// Example: `✓ Read ×12 | ✓ Bash ×8 | ✓ Edit ×5` (6 per line, wraps if needed)
+fn format_completed_tool_lines(
     frame: &RenderFrame,
     config: &RenderConfig,
     tier: &EmphasisTier,
-) -> String {
+) -> Vec<String> {
     let color = config.color_enabled;
     let sep = colorize(" | ", tier.separator, color);
+    let per_line = config.tools_per_line.max(1);
 
-    let parts: Vec<String> = frame
+    frame
         .completed_tools
-        .iter()
-        .map(|completed| {
-            let check = colorize("✓", COMPLETED_CHECK, color);
-            let name_str = colorize(&completed.name, COMPLETED_CHECK, color);
-            let count_str = colorize(&format!(" ×{}", completed.count), tier.secondary, color);
-            format!("{check} {name_str}{count_str}")
+        .chunks(per_line)
+        .map(|chunk| {
+            let parts: Vec<String> = chunk
+                .iter()
+                .map(|completed| {
+                    let check = colorize("✓", COMPLETED_CHECK, color);
+                    let name_str = colorize(&completed.name, COMPLETED_CHECK, color);
+                    let count_str =
+                        colorize(&format!(" ×{}", completed.count), tier.secondary, color);
+                    format!("{check} {name_str}{count_str}")
+                })
+                .collect();
+            parts.join(&sep)
         })
-        .collect();
-
-    parts.join(&sep)
+        .collect()
 }
 
 /// Format the recent/running tools line with targets.

--- a/src/state/cache.rs
+++ b/src/state/cache.rs
@@ -32,7 +32,7 @@ pub struct SessionCache {
     pub recent_tools: Vec<ToolSummary>,
     pub active_agents: Vec<AgentSummary>,
     pub completed_agents: Vec<AgentSummary>,
-    pub completed_tool_counts: HashMap<String, u32>,
+    pub completed_tool_counts: HashMap<String, (u32, u64)>,
     pub todo: Option<TodoSummary>,
     // Agent linking
     #[serde(default)]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -25,7 +25,7 @@ pub struct SessionState {
     pub recent_tools: Vec<ToolSummary>,
     pub active_agents: Vec<AgentSummary>,
     pub completed_agents: Vec<AgentSummary>,
-    pub completed_tool_counts: HashMap<String, u32>,
+    pub completed_tool_counts: HashMap<String, (u32, u64)>,
     pub todo: Option<TodoSummary>,
     // Agent linking: Agent tool_use → agent_progress ID linking
     pub pending_tasks: Vec<PendingTask>,
@@ -162,24 +162,50 @@ impl SessionState {
     }
 
     pub fn record_tool_completion(&mut self, name: &str) {
-        *self
+        let now = cache::now_epoch_ms();
+        let entry = self
             .completed_tool_counts
             .entry(name.to_string())
-            .or_insert(0) += 1;
+            .or_insert((0, 0));
+        entry.0 += 1;
+        entry.1 = now;
     }
 
-    pub fn top_completed_tools(&self, max: usize) -> Vec<CompletedToolCount> {
-        let mut counts: Vec<CompletedToolCount> = self
+    /// Hybrid scoring: count + recency bonus (decays over 2 minutes).
+    /// Recently used tools float up even with low counts.
+    pub fn scored_completed_tools(&self, max: usize) -> Vec<CompletedToolCount> {
+        const RECENCY_WEIGHT: f64 = 3.0;
+        const DECAY_WINDOW_MS: u64 = 120_000; // 2 minutes
+
+        let now = cache::now_epoch_ms();
+        let mut scored: Vec<(CompletedToolCount, f64)> = self
             .completed_tool_counts
             .iter()
-            .map(|(name, count)| CompletedToolCount {
-                name: name.clone(),
-                count: *count,
+            .map(|(name, (count, last_at))| {
+                let age_ms = now.saturating_sub(*last_at);
+                let recency = if age_ms < DECAY_WINDOW_MS {
+                    RECENCY_WEIGHT * (1.0 - age_ms as f64 / DECAY_WINDOW_MS as f64)
+                } else {
+                    0.0
+                };
+                let score = *count as f64 + recency;
+                (
+                    CompletedToolCount {
+                        name: name.clone(),
+                        count: *count,
+                        last_completed_at: Some(*last_at),
+                    },
+                    score,
+                )
             })
             .collect();
-        counts.sort_by(|a, b| b.count.cmp(&a.count).then(a.name.cmp(&b.name)));
-        counts.truncate(max);
-        counts
+        scored.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a.0.name.cmp(&b.0.name))
+        });
+        scored.truncate(max);
+        scored.into_iter().map(|(tool, _)| tool).collect()
     }
 
     pub fn upsert_agent(
@@ -559,5 +585,68 @@ mod tests {
         let now = cache::now_epoch_ms();
         state.last_quota_fetch_spawned_ms = Some(now.saturating_sub(20_000));
         assert!(state.should_spawn_quota_fetch(15_000));
+    }
+
+    #[test]
+    fn scored_completed_tools_recent_low_count_beats_stale_moderate_count() {
+        let mut state = SessionState::default();
+        let now = cache::now_epoch_ms();
+
+        // Moderate count tool, last used 3 minutes ago (beyond 2-min decay window)
+        // Score: 3 + 0 = 3.0
+        state
+            .completed_tool_counts
+            .insert("Grep".to_string(), (3, now.saturating_sub(180_000)));
+
+        // Low count tool, used just now
+        // Score: 1 + 3.0 = 4.0
+        state
+            .completed_tool_counts
+            .insert("Skill".to_string(), (1, now));
+
+        let top = state.scored_completed_tools(2);
+        assert_eq!(top[0].name, "Skill", "recent tool should rank first");
+        assert_eq!(top[1].name, "Grep", "stale tool should rank second");
+    }
+
+    #[test]
+    fn scored_completed_tools_count_dominates_after_decay() {
+        let mut state = SessionState::default();
+        let now = cache::now_epoch_ms();
+
+        // Both tools last used 3 minutes ago (beyond 2-min decay window)
+        state
+            .completed_tool_counts
+            .insert("Read".to_string(), (15, now.saturating_sub(180_000)));
+        state
+            .completed_tool_counts
+            .insert("Skill".to_string(), (1, now.saturating_sub(180_000)));
+
+        let top = state.scored_completed_tools(2);
+        assert_eq!(
+            top[0].name, "Read",
+            "higher count should win when both are stale"
+        );
+    }
+
+    #[test]
+    fn scored_completed_tools_tiebreak_alphabetical() {
+        let mut state = SessionState::default();
+        let now = cache::now_epoch_ms();
+
+        // Same count, same recency
+        state
+            .completed_tool_counts
+            .insert("Edit".to_string(), (5, now));
+        state
+            .completed_tool_counts
+            .insert("Bash".to_string(), (5, now));
+
+        let top = state.scored_completed_tools(2);
+        assert_eq!(
+            top[0].name, "Bash",
+            "alphabetical tiebreak: Bash before Edit"
+        );
+        assert_eq!(top[1].name, "Edit");
     }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -153,22 +153,22 @@ impl SessionState {
         }
     }
 
-    pub fn remove_tool(&mut self, id: &str) {
+    pub fn remove_tool(&mut self, id: &str, event_ts: Option<u64>) {
         if let Some(tool) = self.active_tools.iter().find(|t| t.id == id) {
-            self.record_tool_completion(&tool.name.clone());
+            self.record_tool_completion(&tool.name.clone(), event_ts);
         }
         self.active_tools.retain(|tool| tool.id != id);
         // recent_tools: intentionally NOT touched — tool stays visible until displaced
     }
 
-    pub fn record_tool_completion(&mut self, name: &str) {
-        let now = cache::now_epoch_ms();
+    pub fn record_tool_completion(&mut self, name: &str, event_ts: Option<u64>) {
+        let ts = event_ts.unwrap_or_else(cache::now_epoch_ms);
         let entry = self
             .completed_tool_counts
             .entry(name.to_string())
             .or_insert((0, 0));
         entry.0 += 1;
-        entry.1 = now;
+        entry.1 = ts;
     }
 
     /// Hybrid scoring: count + recency bonus (decays over 2 minutes).

--- a/src/types.rs
+++ b/src/types.rs
@@ -145,6 +145,8 @@ pub struct ToolSummary {
 pub struct CompletedToolCount {
     pub name: String,
     pub count: u32,
+    #[serde(default)]
+    pub last_completed_at: Option<u64>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/tests/activity_pipeline.rs
+++ b/tests/activity_pipeline.rs
@@ -1619,3 +1619,208 @@ fn todo_max_lines_caps_display() {
         "first line should show overflow count when more active than shown: got {first}"
     );
 }
+
+// ── Noise tool filtering + explicit target extraction ─────────────────
+
+#[test]
+fn noise_tools_not_tracked() {
+    let workspace = TempDir::new().expect("temp workspace");
+    let transcript = workspace.path().join("noise.jsonl");
+
+    let noise_events = [
+        r#"{"message":{"role":"assistant","content":[{"type":"tool_use","id":"n1","name":"EnterPlanMode","input":{}}]}}"#,
+        r#"{"message":{"role":"assistant","content":[{"type":"tool_use","id":"n2","name":"TaskGet","input":{"taskId":"1"}}]}}"#,
+        r#"{"message":{"role":"assistant","content":[{"type":"tool_use","id":"n3","name":"ExitWorktree","input":{}}]}}"#,
+        r#"{"message":{"role":"assistant","content":[{"type":"tool_use","id":"n4","name":"ToolSearch","input":{"query":"select:Read"}}]}}"#,
+    ];
+
+    for event in &noise_events {
+        append_line(&transcript, event);
+    }
+
+    let mut runner = PulseLineRunner::default();
+    let config = RenderConfig {
+        transcript_poll_throttle_ms: 0,
+        ..RenderConfig::default()
+    };
+
+    let lines = runner
+        .run_from_str(&payload_json(&workspace, &transcript, "noise-test"), config)
+        .expect("render should succeed");
+
+    let joined = lines.join("\n");
+    assert!(
+        !joined.contains("EnterPlanMode"),
+        "noise tool EnterPlanMode should not appear: {joined}"
+    );
+    assert!(
+        !joined.contains("TaskGet"),
+        "noise tool TaskGet should not appear: {joined}"
+    );
+    assert!(
+        !joined.contains("ExitWorktree"),
+        "noise tool ExitWorktree should not appear: {joined}"
+    );
+    assert!(
+        !joined.contains("ToolSearch"),
+        "noise tool ToolSearch should not appear: {joined}"
+    );
+    assert!(
+        !joined.contains("T:"),
+        "no tool lines should appear at all: {joined}"
+    );
+}
+
+#[test]
+fn skill_and_ask_targets_extracted() {
+    let workspace = TempDir::new().expect("temp workspace");
+    let transcript = workspace.path().join("targets.jsonl");
+
+    let events = [
+        r#"{"message":{"role":"assistant","content":[{"type":"tool_use","id":"s1","name":"Skill","input":{"skill":"commit"}}]}}"#,
+        r#"{"message":{"role":"assistant","content":[{"type":"tool_use","id":"a1","name":"AskUserQuestion","input":{"questions":[{"question":"Which database should we use?"}]}}]}}"#,
+        r#"{"message":{"role":"assistant","content":[{"type":"tool_use","id":"m1","name":"SendMessage","input":{"to":"code-reviewer","message":"Please review"}}]}}"#,
+        r#"{"message":{"role":"assistant","content":[{"type":"tool_use","id":"l1","name":"LSP","input":{"command":"getDefinition","path":"/src/main.rs"}}]}}"#,
+    ];
+
+    for event in &events {
+        append_line(&transcript, event);
+    }
+
+    let mut runner = PulseLineRunner::default();
+    let config = RenderConfig {
+        transcript_poll_throttle_ms: 0,
+        max_tool_lines: 4,
+        ..RenderConfig::default()
+    };
+
+    let lines = runner
+        .run_from_str(
+            &payload_json(&workspace, &transcript, "target-test"),
+            config,
+        )
+        .expect("render should succeed");
+
+    let joined = lines.join("\n");
+    assert!(
+        joined.contains("commit"),
+        "Skill target 'commit' should appear: {joined}"
+    );
+    assert!(
+        joined.contains("Which database"),
+        "AskUserQuestion target should appear: {joined}"
+    );
+    assert!(
+        joined.contains("code-reviewer"),
+        "SendMessage target should appear: {joined}"
+    );
+    assert!(
+        joined.contains("getDefinition"),
+        "LSP target should appear: {joined}"
+    );
+}
+
+// ── Completed tools line wrapping ─────────────────────────────────────
+
+#[test]
+fn completed_tools_wraps_to_multiple_lines() {
+    let workspace = TempDir::new().expect("temp workspace");
+    let transcript = workspace.path().join("wrap.jsonl");
+
+    // Create 8 different tools, each with a use + result pair
+    let tools = [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash",
+        "Grep",
+        "Glob",
+        "WebFetch",
+        "WebSearch",
+    ];
+    for (i, tool_name) in tools.iter().enumerate() {
+        let id = format!("w{i}");
+        let input = match *tool_name {
+            "Read" | "Write" | "Edit" => r#""file_path":"/src/main.rs""#,
+            "Bash" => r#""command":"echo hi""#,
+            "Grep" | "Glob" => r#""pattern":"*.rs""#,
+            "WebFetch" => r#""url":"https://example.com""#,
+            "WebSearch" => r#""query":"rust async""#,
+            _ => "",
+        };
+        let tool_use = format!(
+            r#"{{"message":{{"role":"assistant","content":[{{"type":"tool_use","id":"{id}","name":"{tool_name}","input":{{{input}}}}}]}}}}"#
+        );
+        let tool_result = format!(
+            r#"{{"message":{{"role":"assistant","content":[{{"type":"tool_result","tool_use_id":"{id}"}}]}}}}"#
+        );
+        append_line(&transcript, &tool_use);
+        append_line(&transcript, &tool_result);
+    }
+
+    let mut runner = PulseLineRunner::default();
+    let config = RenderConfig {
+        transcript_poll_throttle_ms: 0,
+        max_completed_tools: 8,
+        tools_per_line: 6,
+        ..RenderConfig::default()
+    };
+
+    let lines = runner
+        .run_from_str(&payload_json(&workspace, &transcript, "wrap-test"), config)
+        .expect("render should succeed");
+
+    // Count lines containing ✓ (completed tool markers)
+    let completed_lines: Vec<&String> = lines.iter().filter(|l| l.contains("✓")).collect();
+    assert_eq!(
+        completed_lines.len(),
+        2,
+        "8 tools at 6 per line should produce 2 completed lines: got {completed_lines:?}"
+    );
+}
+
+#[test]
+fn completed_tools_single_line_when_under_per_line() {
+    let workspace = TempDir::new().expect("temp workspace");
+    let transcript = workspace.path().join("single.jsonl");
+
+    // Create 3 tools
+    for (i, tool_name) in ["Read", "Edit", "Bash"].iter().enumerate() {
+        let id = format!("s{i}");
+        let input = match *tool_name {
+            "Read" | "Edit" => r#""file_path":"/src/main.rs""#,
+            "Bash" => r#""command":"echo hi""#,
+            _ => "",
+        };
+        let tool_use = format!(
+            r#"{{"message":{{"role":"assistant","content":[{{"type":"tool_use","id":"{id}","name":"{tool_name}","input":{{{input}}}}}]}}}}"#
+        );
+        let tool_result = format!(
+            r#"{{"message":{{"role":"assistant","content":[{{"type":"tool_result","tool_use_id":"{id}"}}]}}}}"#
+        );
+        append_line(&transcript, &tool_use);
+        append_line(&transcript, &tool_result);
+    }
+
+    let mut runner = PulseLineRunner::default();
+    let config = RenderConfig {
+        transcript_poll_throttle_ms: 0,
+        max_completed_tools: 8,
+        tools_per_line: 6,
+        ..RenderConfig::default()
+    };
+
+    let lines = runner
+        .run_from_str(
+            &payload_json(&workspace, &transcript, "single-test"),
+            config,
+        )
+        .expect("render should succeed");
+
+    let completed_lines: Vec<&String> = lines.iter().filter(|l| l.contains("✓")).collect();
+    assert_eq!(
+        completed_lines.len(),
+        1,
+        "3 tools at 6 per line should produce 1 completed line: got {completed_lines:?}"
+    );
+}

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -72,7 +72,7 @@ fn version_flag_shows_version() {
         stdout.contains("cc-pulseline"),
         "should contain binary name"
     );
-    assert!(stdout.contains("1.0.3"), "should contain version number");
+    assert!(stdout.contains("1.0.4"), "should contain version number");
 }
 
 #[test]
@@ -85,7 +85,7 @@ fn short_version_flag_works() {
     assert!(output.status.success(), "should exit 0");
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(
-        stdout.contains("cc-pulseline 1.0.3"),
+        stdout.contains("cc-pulseline 1.0.4"),
         "should show name and version"
     );
 }

--- a/tests/core_metrics.rs
+++ b/tests/core_metrics.rs
@@ -454,6 +454,7 @@ fn completed_tools_use_check_color() {
     frame.completed_tools.push(CompletedToolCount {
         name: "Read".to_string(),
         count: 5,
+        last_completed_at: None,
     });
 
     let lines = render_frame(&frame, &colored_config());


### PR DESCRIPTION
## Summary

- **Noise tool filtering** — 9 internal Claude Code tools (EnterPlanMode, ExitPlanMode, EnterWorktree, ExitWorktree, TaskGet, TaskList, TaskOutput, TaskStop, ToolSearch) excluded from tool tracking across both Path 1 (nested content) and Path 3 (flat fallback)
- **Hybrid tool scoring** — Completed tools ranked by `count + recency_bonus` (2-minute decay window) so recently used tools float up even with low counts
- **Expanded target extraction** — Skill, AskUserQuestion, SendMessage, LSP, WebFetch, WebSearch, NotebookEdit, plus generic fallback chain for unknown tools
- **Multi-line completed tools** — `tools_per_line` config (default 6) wraps completed tool counts across multiple lines
- **Bug fix** — Noise filtering was missing from Path 3 flat format transcript parsing; moved `NOISE_TOOLS` to module level so both paths share it

## Test plan

- [x] All 203 tests pass (`cargo test`)
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] Version bump to 1.0.4 in Cargo.toml, README, CLI tests
- [x] CHANGELOG, README, architecture docs, and metrics reference updated