### PR TITLE
feat(palette): decouple L1 HEAD pills + ledger TAG from inherited tiers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "pulseline",
       "description": "Setup and manage the cc-pulseline statusline — install binary, configure display, and diagnose issues",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "source": ".",
       "category": "productivity"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pulseline",
   "description": "High-performance multi-line statusline for Claude Code with setup commands and diagnostics",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "cc-pulseline"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-05-01
+
+Decouple the L1 HEAD pills (`AG:` agent, `[T]` thinking) and the ledger
+TAG column from the inherited palette tiers they were borrowing colors
+from. Themers can now tune each role independently, and the M:/AG:
+collision on L1 is fixed in every built-in theme.
+
+### Added
+
+- **`tag_label` / `head_agent` / `head_thinking` palette fields** — Three
+  new optional `ThemePalette` slots for layout-specific roles. Each
+  falls back to the prior tier when absent from theme JSON
+  (`secondary` / `active_purple` / `active_amber`), so existing custom
+  themes keep working unchanged. Override via `[colors]` TOML section
+  or per-theme JSON. Same pattern as `strata_*` and `aurora_*`.
+- **"Heads & Tag" section in `--palette-map`** — Runtime palette anatomy
+  printer lists the new fields alongside the existing tier sections.
+  L1 anatomy preview also gains `AG:greg-bot` and `[T]` rows.
+
+### Changed
+
+- **L1 `AG:` pill rewired to `head_agent`** — Was `stable_blue`,
+  visually colliding with the `M:` model pill. Default fallback puts
+  AG: on `active_purple` so it matches L5+ `A:Explore` agent rows.
+- **L1 `[T]` thinking pill rewired to `head_thinking`** — Was
+  `active_purple` (collided with the agent purple). Default fallback
+  is `active_amber`.
+- **Ledger TAG column rewired to `tag_label`** — Was `secondary`,
+  dragging L1 secondary text along with any TAG tuning.
+- **Macro 4-group label `Config` → `ENV`** in zones / grid / sections /
+  console layouts. Aligns with the ledger TAG vocabulary
+  (`ENV / CTX / TOK / COST / ...`) and the underlying `EnvCollector`
+  provider. No config schema change; only the rendered group label.
+- **Per-theme intentional values for all 10 built-in themes.** Each
+  theme authors `tag_label / head_agent / head_thinking` designed
+  for that theme's palette story. Mono-accent themes preserve their
+  contract on the activity tier; `head_agent` on L1 diverges where
+  needed for visual disambiguation (e.g. echo-sub-zero picks
+  `active_coral` for AG: rather than colliding with `stable_blue`).
+
+### Fixed
+
+- **`identity_headline` (Console / Ledger frame title) AG / [T] colors.**
+  The title-hoist formatter had its own duplicate copy of the AG / [T]
+  color path that wasn't picked up by the L1 rewire on first pass. It
+  now reads the same `head_agent` / `head_thinking` fields as the flat
+  L1 formatter.
+
 ## [1.1.0] - 2026-04-30
 
 > **⚠ Breaking changes** are clearly marked below. The `[pane]` → `[layout]`
@@ -295,6 +343,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Context alert thresholds** at 70%/55% — warnings appear before Claude Code's ~80% auto-compact triggers
 - **Steel blue completed checkmarks** — distinct from plan-mode green to avoid visual collision
 
+[1.1.1]: https://github.com/GregoryHo/cc-pulseline/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/GregoryHo/cc-pulseline/compare/v1.0.6...v1.1.0
 [1.0.6]: https://github.com/GregoryHo/cc-pulseline/compare/v1.0.5...v1.0.6
 [1.0.5]: https://github.com/GregoryHo/cc-pulseline/compare/v1.0.4...v1.0.5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ stdin JSON → StdinPayload (deserialize)
   - `pane.rs` — `LayoutStyle` enum (6 variants: `None`/`Zones`/`Grid`/`Sections`/`Console`/`Ledger`) + `PaneConfig` chrome wrapper. `apply_pane()` decorates the assembled lines with frame chrome.
   - `frames/` — Per-layout `render()` fns: `zones`, `grid`, `sections`, `console`, `ledger`. `console` is a thin shim that calls `sections::render_with_options` with the Identity row hoisted into the top frame title. `frames/shared.rs` holds the box-drawing glyphs, label/content padding, identity headline, config row, and the per-segment dispatch hubs (`render_context_visual` and `render_quota_visual` — each maps a `+`-joined visual spec onto `widgets::gauge::render` / `widgets::sparkline::render` / inline text cells). `frames/mod.rs::default_visuals_for(LayoutStyle)` is the per-layout `*_visual` defaults table.
   - `widgets/` — Atomic widget renderers: `gauge` (bracketless marks-on-track — `▰` filled / `─` empty / `·` threshold marks in Icon mode, `=` / `-` / `:` in Ascii) and `sparkline` (braille, icon-only — caller picks the fill color). Both take `(data, …, marks, mode, palette, color)` shape; ascii-incompatible widgets return `""` so dispatch hubs drop them cleanly. `gauge`'s `width` is the visible cell count (no frame); caller supplies threshold marks (CTX → `ThemePalette::ctx_marks()` = `[55, 70]`; quota → `[50, 85]`).
-  - `color.rs` — `ThemePalette` struct (31 color fields), built-in theme loading (JSON via `include_str!`), custom theme discovery (`~/.claude/pulseline/themes/`), `resolve_palette()` for theme+variant+overrides resolution, legacy `pub const` color values for test compatibility, and `colorize()`/`strip_ansi()` utilities
+  - `color.rs` — `ThemePalette` struct (34 color fields), built-in theme loading (JSON via `include_str!`), custom theme discovery (`~/.claude/pulseline/themes/`), `resolve_palette()` for theme+variant+overrides resolution, legacy `pub const` color values for test compatibility, and `colorize()`/`strip_ansi()` utilities
   - `fmt.rs` — Number formatting (`format_number`), duration formatting (`format_duration`), speed formatting (`format_speed`), reset duration formatting (`format_reset_duration`), and agent/todo elapsed formatting (`format_agent_elapsed`)
   - `icons.rs` — Nerd Font icon constants and `glyph()` helper for icon/ascii mode switching
 
@@ -126,7 +126,7 @@ Test fixtures live in `tests/fixtures/` as `.json` (stdin payloads) and `.jsonl`
 
 ### Color System
 
-The project uses a `ThemePalette` struct with 31 ANSI 256-color fields, resolved at runtime by `resolve_palette(theme, variant, overrides)`. See `docs/theme-palette.md` for the full specification. Key principles:
+The project uses a `ThemePalette` struct with 34 ANSI 256-color fields, resolved at runtime by `resolve_palette(theme, variant, overrides)`. See `docs/theme-palette.md` for the full specification. Key principles:
 
 - **Built-in themes** — JSON files in `src/themes/` embedded via `include_str!()`. tokyo-night is the default; the directory is the source of truth for the full set.
 - **Custom themes** — JSON files in `~/.claude/pulseline/themes/` loaded at runtime with per-process caching

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc-pulseline"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "criterion",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc-pulseline"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 rust-version = "1.85"
 description = "High-performance multi-line statusline for Claude Code with deep observability"

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Recognized widgets: `gauge`, `sparkline`, `text` for context; `gauge`, `text` fo
 ## CLI Usage
 
 ```
-cc-pulseline 1.1.0 - High-performance Claude Code statusline
+cc-pulseline 1.1.1 - High-performance Claude Code statusline
 
 USAGE:
     cc-pulseline [OPTIONS]

--- a/designs/palette-head-fields-review.md
+++ b/designs/palette-head-fields-review.md
@@ -1,0 +1,257 @@
+# Design review: palette × layout HEAD fields
+
+- **Platform:** CLI / TUI (cc-pulseline statusline)
+- **Primary job:** confirm theme palette covers the new L1 fields, audit cross-layout label vocabulary, and decide whether HEAD-row colors should follow themes.
+- **Reference:** existing `ThemePalette` struct (`src/render/color.rs`), `docs/theme-palette.md`, the 5 frame implementations under `src/render/frames/`.
+- **Source reviewed:** `src/render/{color.rs,layout.rs,pane.rs,frames/*.rs}`, `src/config.rs`, `docs/theme-palette.md`. Most recent feature commit: `5b6964e` (CC 2.1.119+ alignment — adds `show_effort`, `show_thinking`).
+- **Date:** 2026-05-01
+
+---
+
+## 1. 新 HEAD 欄位 vs Theme palette 覆蓋
+
+### 目前 L1 / Identity 列上的欄位
+
+| Toggle | 顯示 | 取色來源 | Palette-aware? |
+|---|---|---|---|
+| `show_model` | `M:Opus` | `p.stable_blue` | ✅ 直接欄位 |
+| `show_effort` *(new)* | `E:high` | `p.color_for_effort_level(level)` → `structural` / `stable_blue` / `active_amber` / `active_coral` / `alert_red` / `secondary` | ✅ **語意函式** — 最佳實踐 |
+| `show_thinking` *(new)* | `[T]` (label-only pill) | `p.active_purple` 直接讀取 | ⚠️ palette-aware,但**沒有語意 alias** |
+| `show_agent` *(new)* | `AG:greg-bot` | `p.stable_blue` 直接讀取 | ⚠️ palette-aware,但**和 M: 撞色** |
+| `show_style` | `S:explanatory` | `p.secondary` | ✅ |
+| `show_version` | `CC:2.1.119` | `p.secondary` | ✅ |
+| `show_project` | `P:~/repo` | `p.secondary` | ✅ |
+| `show_git` + `show_git_stats` | `G:main*↑1` | `p.git_*()` 語意函式 | ✅ 語意函式 |
+| `show_worktree` | `(WT)` (附在 git 後面) | 借用 git 顏色 | ✅ |
+
+### 結論
+- **沒有任何 HEAD 欄位寫死 ANSI 碼或硬編色號** — 都已經跑進 palette。換 theme 不會壞。
+- 但 `effort` 是「設立語意 alias」的乾淨範本 (`color_for_effort_level`),`thinking` 和 `agent` 沒享受到同等待遇 — 它們直接讀 `p.active_purple` / `p.stable_blue`,**theme 作者沒辦法只移動 thinking 或 agent 的色相而不影響其他用該欄位的元素**。
+
+### 衝突點
+
+1. **`AG:` 和 `M:` 都是 `stable_blue`** — L1 上目視幾乎分不開:
+   ```
+   M:Opus | AG:greg-bot | S:...
+   ──── 兩個藍色標籤連在一起,只能靠 sep 區隔
+   ```
+   而 L5+ 的 agent 列(`A:Explore`)用的是 `active_purple`。同一個概念(agent identity),L1 和 L5+ 用不同色 → 不一致。
+
+2. **`[T]` thinking pill 和 L5 agent 同樣 `active_purple`** — agent 是動態的、會跑;thinking 是靜態的「mode 開了」標記。共用色但語意層級不同。
+
+---
+
+## 2. CFG vs ENV 用詞稽核
+
+### 兩套並存的命名系統
+
+```
+                Macro 4-group           Per-metric TAG
+                (zones/grid/sections    (ledger only)
+                 /console PaneGroup)
+   L1 Identity  "Identity"              (升到 frame title,無 tag)
+   L2 Config    "Config"        ←→      "ENV"     ⚠️ 同一列,兩個名字
+   L3 Budget    "Budget"        ←→      "CTX" / "TOK" / "COST" / "5h" / "7d"
+   L4+ Activity "Activity"      ←→      "TOOL" / "AGENT" / "TODO"
+```
+
+### Findings
+
+- **L2 兩個名字最明顯**:macro 系統叫 `Config`,ledger TAG 叫 `ENV`。同一份資料(CLAUDE.md / rules / memories / hooks / MCPs / skills)。
+- **底層 provider 是 `env.rs` / `EnvCollector`** — 內部一直叫 ENV,UI 卻一半叫 Config 一半叫 ENV。
+- **Budget 沒這個問題,但理由不同** — macro 把 CTX+TOK+COST+quota 合成一個 group label,ledger 是「拆開 per-metric」。這是**設計上的分歧,不是命名上的不一致**(每個 layout 在密度光譜上選不同點)。
+- **真正可以收斂的只有 L2** — 因為 ledger 的 `ENV` 沒有「拆開」,就一個 row。
+
+### 推薦
+
+挑一個詞,改另一個。**選 `ENV`** 比較合適,理由:
+
+| 比較 | `Config` | `ENV` |
+|---|---|---|
+| 對齊 provider 名稱 | ✗ (`EnvCollector`) | ✓ |
+| 字數 | 6 | 3,和 CTX/TOK/COST 韻律一致 |
+| 和 TOML 設定撞名 | ✗ `--print config` 會混淆 | ✓ |
+| 對使用者意涵 | 偏設定檔 | 偏「環境掃描結果」(含 hooks/MCPs/skills) |
+
+→ 把 `src/render/layout.rs:161` 的 `"Config"` 改成 `"ENV"`,順便把 `LineKind::Config` 重新命名為 `LineKind::Env`(or 保留 enum 名稱,只動 user-facing label)。
+
+---
+
+## 3. 新 HEAD 欄位是否能參考 theme 顏色做變化?
+
+**Yes,而且現在就已經是這樣 —** 但有 3 個 polish 機會。
+
+### Adjustments
+
+#### Must
+
+**M1. `Config` → `ENV` 統一** (lens: Consistency)
+- 現況:同一列在 ledger 叫 ENV,在其他 4 個 layout 叫 Config。
+- 動作:`src/render/layout.rs:161` 把 PaneGroup label 改 `"Config"` → `"ENV"`(或用設定檔可覆寫的常數)。也更新 `docs/theme-palette.md` line 411 區的 ASCII art。
+- 驗收:`cargo test`,並抽一個 grid + 一個 ledger 截圖比對 label 一致。
+
+#### Should
+
+**S1. 為 `agent` 和 `thinking` 加語意 alias** (lens: Affordance + Theme separability)
+- 現況:`format_line1` 直接寫 `p.stable_blue`(agent)、`p.active_purple`(thinking)。Theme 作者要把 thinking 從紫色換成琥珀色,得連動所有 `active_purple` 用法。
+- 動作:在 `ThemePalette` 加兩個語意函式:
+  ```rust
+  pub fn agent_identity(&self) -> &str { &self.active_purple }   // L1 AG: + L5 A:
+  pub fn thinking_pill(&self) -> &str  { &self.active_amber }    // 或 dedicated 新欄位
+  ```
+- 預期效果:`AG:greg-bot` 在 L1 變紫色,和 L5 `A:Explore` 顏色一致;thinking 從紫色獨立出來,不再和 agent 撞色。
+- 驗收:更新 `docs/theme-palette.md` Line 1 ASCII annotation;新增 `ThemePalette` test 確保兩個 alias 在 tokyo-night dark 下分別 = 183 / 178。
+
+**S2. L1 上 `M:` 和 `AG:` 撞色** (lens: Hierarchy)
+- 現況:兩者都 `stable_blue`,L1 「主要身份 vs session agent」的層級被壓平。
+- 動作:跟 S1 合併 — `AG:` 改用 `agent_identity()`(紫色),`M:` 維持 `stable_blue`。Model 是 primary identity,agent 是 secondary identity,兩種藍綠紫的層級就出來。
+- 驗收:`tests/agent_worktree.rs` 加一條 assertion 檢查 AG: 顏色 ≠ M: 顏色。
+
+#### Could
+
+**C1. 為 `effort` 開放 theme 微調入口** (lens: Theme expressiveness)
+- 現況:`color_for_effort_level` 用內建語意對照(low→structural / medium→stable_blue / ...)。Theme 作者想讓 `xhigh` 改用其他色就只能改全域 `active_coral`。
+- 動作:在 theme JSON 開放 `effort_low / effort_medium / effort_high / effort_xhigh / effort_max` 欄位(都 `Option<u8>`,預設 fallback 到目前 mapping),套到 palette。
+- 驗收:加 1 個 custom theme,把 `effort_max = 196` 改 `effort_max = 124` 看顏色變化。
+- 為什麼是 Could: 目前 5 階梯 mapping 已經涵蓋大部分 theme 的視覺語意 (低→中→暖→警告),YAGNI 直到有人實際提出。
+
+**C2. 把 ledger TAG 顏色綁到資料種類** (lens: Affordance)
+- 現況:`framed_tag_row` 統一給 TAG 上 `secondary` 色,所有 TAG(ENV/CTX/TOK/COST/TOOL/AGENT/TODO)都長一樣。
+- 動作:讓 TAG 取它自己 row 的主色 — `CTX` 用 `color_for_ctx_pct`,`AGENT` 用 `agent_identity()`,`TOOL` 用 `tool_blue`,`COST` 用 `color_for_burn_rate`。TAG 變成「色塊化的圖例」,row 內容變化時 TAG 也呼吸。
+- 為什麼是 Could: 會讓 ledger 從「靜態列表」變「動態儀表板」,有些使用者可能反而覺得吵。先開個 TOML toggle 試水溫(`ledger.dynamic_tag_color = false` default)。
+
+---
+
+## Cross-cutting recommendation
+
+**新增 HEAD 欄位的 checklist**(寫進 `.claude/rules/rendering.md` 那批文件):
+
+1. 顏色從 `&ThemePalette` 拿,不能寫 const
+2. **如果這個欄位代表的「概念」在其他 line 也有出現**(像 agent 在 L1 和 L5),建一個 `pub fn xxx(&self) -> &str` 語意 alias
+3. **如果這個欄位的色階會根據資料變化**(像 effort、cost、ctx),建一個 `pub fn color_for_xxx(...)` 函式,而不是在 `format_line1` 裡用 if/else
+4. 在 `docs/theme-palette.md` Line 1 ASCII annotation 加一行
+5. 給 `tests/` 加一條 assertion,確認 tokyo-night dark 和 light 兩個 variant 都會印出非空字串
+
+---
+
+## Next step
+
+選一條動:S1(agent + thinking 語意 alias)落地最快、回報最高;若想一次清,把 M1 + S1 + S2 包成一個 PR — 都動 `layout.rs` + `color.rs` + `theme-palette.md`,改動範圍剛好同心。
+
+---
+
+# Round 2 — 後續對話補充 (2026-05-01)
+
+## Q: 是否需要 per-layout palette?
+
+**不需要,但要加 palette 欄位。**
+
+- Per-layout palette(每個 layout 一份顏色)= **錯方向**。10 個 theme × 5 個 layout = 50 套色要設計,沒人會做完,跨 layout 視覺一致性反而瓦解。
+- 現在的單一 `ThemePalette` 不會「自動爆」,但會慢慢漂 — 每次新 layout 引入新角色(ledger TAG 欄、console frame title),都會借一個現有欄位 → 該欄位被多義化 → theme 作者再也沒辦法獨立調整。
+- **已經有兩個漂移點:**
+  1. `framed_tag_row` 直接讀 `p.secondary`(ledger TAG 欄借了 L1 secondary 用)
+  2. `format_line1` 直接讀 `p.active_purple`(thinking pill)和 `p.stable_blue`(AG:)
+
+### 既有先例
+
+`strata_state` / `strata_activity` 是「frame chrome 角色,獨立色位,Optional 帶 fallback」的範本。`aurora_low/mid/high` 是「sparkline gradient 角色,獨立色位,Optional 帶 fallback」的範本。同一個機制再用一次。
+
+## 落地計畫(M1 + S1 + S2 + Q3 directive 整合)
+
+### 新增 3 個 palette 欄位
+
+| 新欄位 | 用途 | Fallback(Option = None 時) | 為什麼是新欄位而非 alias |
+|---|---|---|---|
+| `tag_label` | Ledger TAG 欄(ENV/CTX/TOK/COST/...) | `secondary` | TAG 欄出現在每一行,L1 secondary 出現在 1 行;頻率不同,色重應該分開可調 |
+| `head_agent` | L1 `AG:greg-bot` | `active_purple` | 與 L5+ `A:Explore` 同一概念(agent identity),共用語意但 theme 作者可能想 L1 比 L5 更收斂 |
+| `head_thinking` | L1 `[T]` pill | `active_amber` | thinking ≠ agent;借 `active_purple` 會撞色,借 `active_amber` 又綁住 effort medium-high |
+
+每個欄位都走 `Option<u8>` + `#[serde(default)]`,custom theme 漏寫 → 落 fallback + warn-once,和 `strata_*` 一致。
+
+### 新增 3 個 semantic 函式
+
+```rust
+impl ThemePalette {
+    pub fn tag_label(&self) -> &str { &self.tag_label }
+    pub fn head_agent(&self) -> &str { &self.head_agent }
+    pub fn head_thinking(&self) -> &str { &self.head_thinking }
+}
+```
+
+(欄位/函式同名 — Rust 允許,跟 `strata_state` 同模式。)
+
+### 改動清單
+
+**`src/render/color.rs`**
+- `ThemePalette` 加 3 個 `String` 欄位
+- `PresetColors` 加 3 個 `Option<u8>` 欄位(`#[serde(default)]`)
+- `LightEmphasis` 同步加(讓 light variant 可獨立指定)
+- `build_palette` 加 fallback:`tag_label → secondary`、`head_agent → active_purple`、`head_thinking → active_amber`
+- `apply_color_overrides` 加 3 條 `apply!`
+- `warn_*_fallback_once` 模式加一個(或合併成一個 generic warn)
+- 加 `pub fn builtin_*_for(name, variant)` 給 contrast lint 用(如果有)
+
+**`src/config.rs`**
+- `ColorsConfig` 加 3 個 `Option<u8>`
+
+**`src/render/layout.rs`**
+- L160-172 `pane_config_from`:`"Config"` → `"ENV"`(M1)
+- `format_line1` AG::`&p.stable_blue` → `p.head_agent()`(S2)
+- `format_line1` `[T]` pill:`&p.active_purple` → `p.head_thinking()`(S1)
+
+**`src/render/frames/ledger.rs`**
+- `framed_tag_row` line 259:`&ctx.p.secondary` → `ctx.p.tag_label()`
+
+**`src/themes/*.json`**(10 個 built-in)
+- 每個 theme 加 3 個欄位到 `palette_mapping`,並在 `light_emphasis` 視需要 override
+- ⚠️ **這是設計工作,不是 boilerplate** — 每個 theme 要按自己的 palette 故事決定數值。例如:
+  - `cyberdeck-hud`(neon):`head_thinking` 可以選比 amber 更亮的霓虹色 → 配合整體高飽和度
+  - `titanium-precision`(desaturated):`tag_label` 應該比 secondary 更弱(把 ledger TAG 欄壓成「次要結構元素」),`head_thinking` 用接近 active_coral 的濁色
+  - `tokyo-night`(reference):安全值就是 fallback(146 / 183 / 178)
+- **不要全部塞 fallback 值** — 那等於沒設計
+
+**`docs/theme-palette.md`**
+- 加 3 個欄位的說明 + role rationale
+- 更新 Line 1 ASCII annotation(把 AG: 從 stable_blue 改 active_purple,加 [T] head_thinking 標註)
+- 更新 ledger 範例的 TAG 顏色標註
+- L2 由 "Config" 改 "ENV" 的小段(macro 4-group 的 group label)
+
+**測試**
+- `tests/agent_worktree.rs` 加 `AG:` 色 ≠ `M:` 色 assertion
+- `src/render/color.rs` mod tests:tokyo-night dark 下 `head_agent != head_thinking`(避免兩者撞色 regression)
+- `tests/cli_flags.rs` 或既有 ledger 測試:把 ENV TAG 色從 secondary 解耦的 assertion(ledger 套 custom theme,只覆寫 `tag_label`,確認 secondary 不受影響)
+- Ascii catch-net:不影響(這幾個變動不引入新 Unicode glyph)
+
+### 建議分 commit
+
+可一個 PR 三個 commit,降 review 負擔:
+
+1. **`feat(palette): add tag_label / head_agent / head_thinking fields`**
+   - 純加欄位 + fallback + semantic 函式 + override apply
+   - 渲染端不動,所有 layout 視覺零變化
+   - Tests:palette unit tests(欄位存在 + fallback 行為 + override 套用)
+2. **`feat(layout): rewire L1 AG/thinking + ledger TAG to new palette fields; rename Config→ENV`**
+   - M1 + S1 + S2 主刀
+   - Built-in theme JSON 暫不動,全部走 fallback(視覺只在 AG: 紫化、thinking 變琥珀色)
+3. **`feat(themes): per-theme designed values for tag_label / head_agent / head_thinking`**
+   - 10 個 JSON 各自設計
+   - 把 Round 2 表格的設計理由寫成 commit message / PR body
+
+如果只想一個 commit,順序也是這樣 — 先擴 palette,再 rewire,最後 polish theme 數值。
+
+### 不做的事
+
+- ❌ 不為 console 的 frame title 拆色位 — 它直接複用 L1 identity 段(model+path+branch),沒新角色。
+- ❌ 不為 zones 的 `──── activity ────` rule 拆色位 — 已經用 `secondary`,語意對齊「分節標籤」,不衝突。
+- ❌ 不為每個 layout 拆 cost / quota / ctx 顏色 — 這些角色已經有自己的色階(`color_for_burn_rate` 等),跨 layout 一致是優點不是 bug。
+- ❌ 不在這個 PR 動 `effort_*` 拆位(C1) — 等真實使用者要求,YAGNI。
+
+## Updated next step
+
+```
+PR 1: palette 欄位擴張 (commit a)        ──┐
+PR 1: rewire + ENV 改名 (commit b)        ──┼─── 同一 PR
+PR 1: 10 個 theme JSON 設計 (commit c)    ──┘
+```
+
+預估:commit a 30 分鐘、commit b 20 分鐘、commit c 1-2 小時(設計 10 個 theme 的 3 個新欄位數值是慢的部分)。

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -95,7 +95,7 @@ estate above all else.
 ### `zones` — single labelled rule between state and activity
 
 Inserts one horizontal rule (`─── activity ───`) between the **state**
-rows (Identity / Config / Budget) and the **activity** rows (Tools /
+rows (Identity / ENV / Budget) and the **activity** rows (Tools /
 Agents / Todos). Echoes Claude Code's own input-box rules so the
 statusline reads as a continuation of CC chrome.
 
@@ -122,7 +122,7 @@ lines up.
 
 ```
 Identity  │ M:Opus 4.7 | S:explanatory | CC:2.1.119 | P:~/cc-pulseline
-Config    │ 1 CLAUDE.md | 5 rules | 2 memories | 1 hooks | 2 MCPs
+ENV       │ 1 CLAUDE.md | 5 rules | 2 memories | 1 hooks | 2 MCPs
 Budget    │ CTX:43% (86.0k/200.0k) | TOK I:10 O:20 | $3.50
 Activity  │ T:Read main.rs | T:Bash cargo test
           │ A:Explore [haiku]: Investigate logic (2m)
@@ -158,7 +158,7 @@ into the top frame border:
 
 ```
 ╭─ Opus 4.7 · medium · ~/cc-pulseline · feat/x* ──────────────────────────╮
-│ Config   │ 󰈙 2 CLAUDE.md | 󰱇 10 rules | 󰧜 4 memories | 󱭧 36 hooks       │
+│ ENV      │ 󰈙 2 CLAUDE.md | 󰱇 10 rules | 󰧜 4 memories | 󱭧 36 hooks       │
 ├──────────┼─────────────────────────────────────────────────────────────┤
 │ Budget   │ CTX:43% (86.0k/200.0k) | TOK I:1 O:8 C:5.7k/114.5k | $4.56  │
 ├──────────┼─────────────────────────────────────────────────────────────┤

--- a/docs/theme-palette.md
+++ b/docs/theme-palette.md
@@ -458,6 +458,11 @@ How each `palette_mapping` field connects to the rendered statusline:
  active_teal ─────────────────────────────────→ TODO:Fixing auth bug
  completed_check ─────────────────────────────→ ✓ All todos complete
  strata_activity ─────────────────────────────→ | (pipes on activity rows when tonal_strata = true)
+
+                                               Ledger TAG column (ledger layout only)
+ tag_label ───────────────────────────────────→ ENV / CTX / TOK / COST / TOOL / AGENT / TODO
+                                                 (the per-row TAG label that anchors each
+                                                  ledger row's left-hand column)
 ```
 
 ### JSON File Structure

--- a/docs/theme-palette.md
+++ b/docs/theme-palette.md
@@ -357,7 +357,7 @@ Drop a JSON file in `~/.claude/pulseline/themes/` and set `theme` to its filenam
    cp src/themes/echo-sub-zero.json ~/.claude/pulseline/themes/my-theme.json
    ```
 
-2. Edit `palette_mapping` — these are the 31 ANSI 256-color codes that control rendering:
+2. Edit `palette_mapping` — these are the 34 ANSI 256-color codes that control rendering:
 
    | Field | Purpose |
    |-------|---------|
@@ -392,6 +392,9 @@ Drop a JSON file in `~/.claude/pulseline/themes/` and set `theme` to its filenam
    | `aurora_low` | Sparkline fill at low CTX-consumption velocity (calm / idle, < 1%/min) |
    | `aurora_mid` | Sparkline fill at mid velocity (active, 1–5%/min) |
    | `aurora_high` | Sparkline fill at high velocity (hot, ≥ 5%/min) |
+   | `tag_label` | Ledger TAG column (ENV / CTX / TOK / COST / TOOL / AGENT / TODO). Falls back to `secondary`. |
+   | `head_agent` | L1 `AG:agent-name` pill (CC `--agent`). Falls back to `active_purple` so it matches L5+ `A:Explore` rows. |
+   | `head_thinking` | L1 `[T]` thinking pill (CC `thinking.enabled`). Falls back to `active_amber` to stay distinct from `head_agent`. |
 
    The strata pair must satisfy `\|state − activity\| ≥ 3` on the ansi256
    scale; the `theme_strata_contrast` test fails CI otherwise. The aurora
@@ -410,6 +413,8 @@ How each `palette_mapping` field connects to the rendered statusline:
  ─────────────────────                         ──────────────────────────────────────────
                                                L1: Identity
  stable_blue ─────────────────────────────────→ M:Opus 4.6
+ head_agent ──────────────────────────────────→ AG:greg-bot (when --agent active; default = active_purple)
+ head_thinking ───────────────────────────────→ [T] (when thinking.enabled; default = active_amber)
  emphasis_secondary ──────────────────────────→ S:explanatory | CC:2.1.80 | P:~/myapp
  stable_green ────────────────────────────────→ G:main (clean branch)
  alert_orange ────────────────────────────────→ G:main* (dirty asterisk)
@@ -464,7 +469,7 @@ theme.json
 ├── "author"               (string, optional)
 ├── "description"          (string, optional)
 │
-├── "palette_mapping"      ★ REQUIRED — the 31 ANSI color codes that control rendering
+├── "palette_mapping"      ★ REQUIRED — the 34 ANSI color codes that control rendering
 │   ├── emphasis_primary        (u8) ─── brightest text: token values, counts
 │   ├── emphasis_secondary      (u8) ─── supporting: style, version, project, targets
 │   ├── emphasis_structural     (u8) ─── labels, icons, metadata text
@@ -495,7 +500,10 @@ theme.json
 │   ├── strata_activity         (u8) ─── chrome on `|` for activity rows
 │   ├── aurora_low              (u8) ─── sparkline fill at low CTX velocity (<1%/min)
 │   ├── aurora_mid              (u8) ─── sparkline fill at mid CTX velocity (1–5%/min)
-│   └── aurora_high             (u8) ─── sparkline fill at high CTX velocity (≥5%/min)
+│   ├── aurora_high             (u8) ─── sparkline fill at high CTX velocity (≥5%/min)
+│   ├── tag_label               (u8, optional) ─── ledger TAG column (defaults to secondary)
+│   ├── head_agent              (u8, optional) ─── L1 AG: pill (defaults to active_purple)
+│   └── head_thinking           (u8, optional) ─── L1 [T] pill (defaults to active_amber)
 │
 ├── "light_emphasis"       (optional — overrides emphasis tiers for light backgrounds)
 │   ├── primary            (u8)
@@ -506,7 +514,10 @@ theme.json
 │   ├── strata_activity    (u8, optional — falls back to dark variant if absent)
 │   ├── aurora_low         (u8, optional — falls back to dark variant if absent)
 │   ├── aurora_mid         (u8, optional — falls back to dark variant if absent)
-│   └── aurora_high        (u8, optional — falls back to dark variant if absent)
+│   ├── aurora_high        (u8, optional — falls back to dark variant if absent)
+│   ├── tag_label          (u8, optional — falls back to dark variant if absent)
+│   ├── head_agent         (u8, optional — falls back to dark variant if absent)
+│   └── head_thinking      (u8, optional — falls back to dark variant if absent)
 │
 ├── "colors"               (optional — design documentation, not consumed by code)
 ├── "element_mapping"      (optional — documents which UI element uses which color)

--- a/src/config.rs
+++ b/src/config.rs
@@ -184,6 +184,15 @@ pub struct ColorsConfig {
     pub aurora_mid: Option<u8>,
     #[serde(default)]
     pub aurora_high: Option<u8>,
+    // HEAD pills + ledger TAG roles. Each gets its own palette slot so
+    // theme authors can re-tune the role without disturbing the tier the
+    // role inherited from. Fallbacks live in `build_palette`.
+    #[serde(default)]
+    pub tag_label: Option<u8>,
+    #[serde(default)]
+    pub head_agent: Option<u8>,
+    #[serde(default)]
+    pub head_thinking: Option<u8>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -728,6 +737,9 @@ pub fn merge_configs(
         merge_color!(aurora_low);
         merge_color!(aurora_mid);
         merge_color!(aurora_high);
+        merge_color!(tag_label);
+        merge_color!(head_agent);
+        merge_color!(head_thinking);
     }
 
     // Segment overrides

--- a/src/config.rs
+++ b/src/config.rs
@@ -184,9 +184,6 @@ pub struct ColorsConfig {
     pub aurora_mid: Option<u8>,
     #[serde(default)]
     pub aurora_high: Option<u8>,
-    // HEAD pills + ledger TAG roles. Each gets its own palette slot so
-    // theme authors can re-tune the role without disturbing the tier the
-    // role inherited from. Fallbacks live in `build_palette`.
     #[serde(default)]
     pub tag_label: Option<u8>,
     #[serde(default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -679,7 +679,7 @@ fn print_palette_map(theme_arg: Option<&str>) {
         color_on,
     );
 
-    // ── Field Reference: all 34 fields by category ──
+    // ── Field Reference ──
 
     println!(
         "{}\n",
@@ -801,10 +801,6 @@ fn print_palette_map(theme_arg: Option<&str>) {
         ],
         color_on,
     );
-    // Heads & Tag — layout-specific roles introduced for L1 HEAD pills
-    // (AG: agent identity, [T] thinking) and the ledger TAG column.
-    // Decoupled from the tier they fall back to so theme authors can
-    // tune them independently.
     print_field_section(
         "Heads & Tag",
         &[

--- a/src/main.rs
+++ b/src/main.rs
@@ -460,8 +460,10 @@ fn print_palette_map(theme_arg: Option<&str>) {
     // L1: Identity
     println!("  L1: Identity");
     println!(
-        "  {} {sep} {} {sep} {} {sep} {}{} {}",
+        "  {} {sep} {} {sep} {} {sep} {} {sep} {} {sep} {}{} {}",
         c("M:Opus 4.6", &p.stable_blue),
+        c("AG:greg-bot", &p.head_agent),
+        c("[T]", &p.head_thinking),
         c("S:explanatory", &p.secondary),
         c("CC:2.1.80", &p.secondary),
         c("G:main", p.git_green()),
@@ -475,6 +477,18 @@ fn print_palette_map(theme_arg: Option<&str>) {
                 "stable_blue",
                 &p.stable_blue,
                 code(&p.stable_blue),
+            ),
+            (
+                "AG:greg-bot",
+                "head_agent",
+                &p.head_agent,
+                code(&p.head_agent),
+            ),
+            (
+                "[T]",
+                "head_thinking",
+                &p.head_thinking,
+                code(&p.head_thinking),
             ),
             ("|", "emphasis_separator", &p.separator, code(&p.separator)),
             (
@@ -665,7 +679,7 @@ fn print_palette_map(theme_arg: Option<&str>) {
         color_on,
     );
 
-    // ── Field Reference: all 26 fields by category ──
+    // ── Field Reference: all 34 fields by category ──
 
     println!(
         "{}\n",
@@ -784,6 +798,19 @@ fn print_palette_map(theme_arg: Option<&str>) {
             (code(&p.aurora_low), "aurora_low", &p.aurora_low),
             (code(&p.aurora_mid), "aurora_mid", &p.aurora_mid),
             (code(&p.aurora_high), "aurora_high", &p.aurora_high),
+        ],
+        color_on,
+    );
+    // Heads & Tag — layout-specific roles introduced for L1 HEAD pills
+    // (AG: agent identity, [T] thinking) and the ledger TAG column.
+    // Decoupled from the tier they fall back to so theme authors can
+    // tune them independently.
+    print_field_section(
+        "Heads & Tag",
+        &[
+            (code(&p.tag_label), "tag_label", &p.tag_label),
+            (code(&p.head_agent), "head_agent", &p.head_agent),
+            (code(&p.head_thinking), "head_thinking", &p.head_thinking),
         ],
         color_on,
     );

--- a/src/render/color.rs
+++ b/src/render/color.rs
@@ -48,6 +48,16 @@ pub struct ThemePalette {
     pub aurora_low: String,
     pub aurora_mid: String,
     pub aurora_high: String,
+    // Layout-specific roles introduced by HEAD additions (effort/thinking/agent
+    // pills on L1) and the ledger TAG column. Each gets its own palette slot
+    // so theme authors can re-tune the role without disturbing the tier the
+    // role inherited from. Fallbacks in `build_palette`:
+    //   tag_label     → secondary
+    //   head_agent    → active_purple   (matches L5+ A:Explore agent rows)
+    //   head_thinking → active_amber    (distinct from head_agent's purple)
+    pub tag_label: String,
+    pub head_agent: String,
+    pub head_thinking: String,
 }
 
 /// CTX threshold percentages — fired by `color_for_ctx_pct` and
@@ -214,6 +224,20 @@ struct PresetColors {
     aurora_mid: Option<u8>,
     #[serde(default)]
     aurora_high: Option<u8>,
+    /// Ledger TAG column color (ENV / CTX / TOK / COST / TOOL / AGENT / TODO).
+    /// Falls back to `secondary` so the role can be tuned without dragging
+    /// L1 secondary text along with it.
+    #[serde(default)]
+    tag_label: Option<u8>,
+    /// L1 `AG:agent-name` color. Falls back to `active_purple` so it visually
+    /// rhymes with L5+ `A:Explore` agent rows (same concept, same color).
+    #[serde(default)]
+    head_agent: Option<u8>,
+    /// L1 `[T]` thinking pill color. Falls back to `active_amber` to keep it
+    /// distinct from `head_agent`'s purple (head_agent and head_thinking must
+    /// not collide on L1).
+    #[serde(default)]
+    head_thinking: Option<u8>,
 }
 
 /// Light variant emphasis overrides (only 4 fields differ from dark, plus
@@ -234,6 +258,12 @@ struct LightEmphasis {
     aurora_mid: Option<u8>,
     #[serde(default)]
     aurora_high: Option<u8>,
+    #[serde(default)]
+    tag_label: Option<u8>,
+    #[serde(default)]
+    head_agent: Option<u8>,
+    #[serde(default)]
+    head_thinking: Option<u8>,
 }
 
 /// Top-level theme JSON file structure.
@@ -267,6 +297,9 @@ fn parse_theme_json(json: &str) -> Result<ThemePreset, String> {
             aurora_low: le.aurora_low.or(dark.aurora_low),
             aurora_mid: le.aurora_mid.or(dark.aurora_mid),
             aurora_high: le.aurora_high.or(dark.aurora_high),
+            tag_label: le.tag_label.or(dark.tag_label),
+            head_agent: le.head_agent.or(dark.head_agent),
+            head_thinking: le.head_thinking.or(dark.head_thinking),
             ..dark
         },
         None => dark,
@@ -415,6 +448,13 @@ fn build_palette(preset: &PresetColors) -> ThemePalette {
         aurora_low: ansi256(preset.aurora_low.unwrap_or(preset.completed_check)),
         aurora_mid: ansi256(preset.aurora_mid.unwrap_or(preset.active_cyan)),
         aurora_high: ansi256(preset.aurora_high.unwrap_or(preset.active_coral)),
+        // Custom themes may omit HEAD/TAG fields → fall back to nearest tier:
+        //   tag_label     → secondary       (ledger TAG defaults to L1 secondary)
+        //   head_agent    → active_purple   (L1 AG: matches L5 A: rows)
+        //   head_thinking → active_amber    (distinct from agent purple)
+        tag_label: ansi256(preset.tag_label.unwrap_or(preset.secondary)),
+        head_agent: ansi256(preset.head_agent.unwrap_or(preset.active_purple)),
+        head_thinking: ansi256(preset.head_thinking.unwrap_or(preset.active_amber)),
     }
 }
 
@@ -458,6 +498,9 @@ pub fn apply_color_overrides(palette: &mut ThemePalette, overrides: &ColorsConfi
     apply!(aurora_low);
     apply!(aurora_mid);
     apply!(aurora_high);
+    apply!(tag_label);
+    apply!(head_agent);
+    apply!(head_thinking);
 }
 
 /// Emit one warning per custom theme name that omits the strata fields.
@@ -939,5 +982,70 @@ mod tests {
     #[test]
     fn ctx_marks_returns_55_70() {
         assert_eq!(ThemePalette::ctx_marks(), [55, 70]);
+    }
+
+    // ── HEAD pills + ledger TAG palette fields ──
+
+    #[test]
+    fn head_and_tag_fields_fall_back_to_existing_tiers_in_tokyo_night() {
+        let p = resolve_palette("tokyo-night", Some("dark"), &ColorsConfig::default());
+        // tokyo-night.json has no tag_label/head_agent/head_thinking yet, so
+        // build_palette must hand them back from the documented fallbacks:
+        // secondary (146), active_purple (183), active_amber (178).
+        assert!(
+            p.tag_label.contains("146"),
+            "tag_label fallback to secondary"
+        );
+        assert!(
+            p.head_agent.contains("183"),
+            "head_agent fallback to active_purple"
+        );
+        assert!(
+            p.head_thinking.contains("178"),
+            "head_thinking fallback to active_amber"
+        );
+    }
+
+    #[test]
+    fn head_agent_and_head_thinking_distinct_in_default_palette() {
+        // head_agent borrows active_purple; head_thinking borrows active_amber.
+        // If a future change collapses them onto the same fallback, L1 will
+        // collide visually — fail loudly here so it's caught early.
+        let p = ThemePalette::default();
+        assert_ne!(
+            p.head_agent, p.head_thinking,
+            "head_agent and head_thinking must render with distinct colors"
+        );
+    }
+
+    #[test]
+    fn apply_overrides_patches_head_and_tag_fields() {
+        let mut p = ThemePalette::default();
+        let overrides = ColorsConfig {
+            tag_label: Some(99),
+            head_agent: Some(100),
+            head_thinking: Some(101),
+            ..ColorsConfig::default()
+        };
+        apply_color_overrides(&mut p, &overrides);
+        assert!(p.tag_label.contains("99"));
+        assert!(p.head_agent.contains("100"));
+        assert!(p.head_thinking.contains("101"));
+    }
+
+    #[test]
+    fn tag_label_decouples_from_secondary_when_overridden() {
+        // Sanity for the role separation rationale: overriding tag_label must
+        // not move secondary, and overriding secondary must not move tag_label
+        // once it has its own value.
+        let mut p = ThemePalette::default();
+        let overrides = ColorsConfig {
+            tag_label: Some(60),
+            secondary: Some(70),
+            ..ColorsConfig::default()
+        };
+        apply_color_overrides(&mut p, &overrides);
+        assert!(p.tag_label.contains("60"));
+        assert!(p.secondary.contains("70"));
     }
 }

--- a/src/render/color.rs
+++ b/src/render/color.rs
@@ -987,11 +987,13 @@ mod tests {
     // ── HEAD pills + ledger TAG palette fields ──
 
     #[test]
-    fn head_and_tag_fields_fall_back_to_existing_tiers_in_tokyo_night() {
+    fn tokyo_night_authors_head_and_tag_fields_at_documented_fallbacks() {
         let p = resolve_palette("tokyo-night", Some("dark"), &ColorsConfig::default());
-        // tokyo-night.json has no tag_label/head_agent/head_thinking yet, so
-        // build_palette must hand them back from the documented fallbacks:
-        // secondary (146), active_purple (183), active_amber (178).
+        // tokyo-night.json explicitly authors these fields at the same values
+        // build_palette would fall back to (secondary 146, active_purple 183,
+        // active_amber 178). The explicit authoring documents intent — tokyo
+        // night is the reference theme and these are deliberately the
+        // canonical values for the role.
         assert!(
             p.tag_label.contains("146"),
             "tag_label fallback to secondary"
@@ -1031,6 +1033,22 @@ mod tests {
         assert!(p.tag_label.contains("99"));
         assert!(p.head_agent.contains("100"));
         assert!(p.head_thinking.contains("101"));
+    }
+
+    #[test]
+    fn every_builtin_theme_keeps_head_agent_distinct_from_head_thinking() {
+        // L1 collision regression: AG: pill and [T] pill must not share a
+        // color in any built-in theme, in either variant. If they collapsed,
+        // the two pills would visually merge on a busy L1.
+        for (name, _) in BUILTIN_THEMES {
+            for variant in [Some("dark"), Some("light")] {
+                let p = resolve_palette(name, variant, &ColorsConfig::default());
+                assert_ne!(
+                    p.head_agent, p.head_thinking,
+                    "theme {name} ({variant:?}) collapses head_agent and head_thinking onto the same color"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/render/color.rs
+++ b/src/render/color.rs
@@ -1052,6 +1052,29 @@ mod tests {
     }
 
     #[test]
+    fn every_builtin_theme_keeps_head_agent_perceptually_apart_from_stable_blue() {
+        // L1 collision regression for the ORIGINAL S2 problem: M: pill (model
+        // identity, `stable_blue`) and AG: pill (`head_agent`) must not land
+        // on the same ANSI cell. ANSI 256 neighbours like 109/110 are within
+        // the same color family — perceptually indistinguishable on most
+        // terminals — so we additionally require that the two values aren't
+        // adjacent integers either.
+        for (name, _) in BUILTIN_THEMES {
+            for variant in [Some("dark"), Some("light")] {
+                let p = resolve_palette(name, variant, &ColorsConfig::default());
+                let stable = extract_ansi_code(&p.stable_blue).unwrap_or(0);
+                let head = extract_ansi_code(&p.head_agent).unwrap_or(0);
+                assert!(
+                    stable.abs_diff(head) > 1,
+                    "theme {name} ({variant:?}) has stable_blue={stable} \
+                     and head_agent={head} — too close to disambiguate \
+                     M: from AG: on L1"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn tag_label_decouples_from_secondary_when_overridden() {
         // Sanity for the role separation rationale: overriding tag_label must
         // not move secondary, and overriding secondary must not move tag_label

--- a/src/render/color.rs
+++ b/src/render/color.rs
@@ -48,13 +48,9 @@ pub struct ThemePalette {
     pub aurora_low: String,
     pub aurora_mid: String,
     pub aurora_high: String,
-    // Layout-specific roles introduced by HEAD additions (effort/thinking/agent
-    // pills on L1) and the ledger TAG column. Each gets its own palette slot
-    // so theme authors can re-tune the role without disturbing the tier the
-    // role inherited from. Fallbacks in `build_palette`:
-    //   tag_label     → secondary
-    //   head_agent    → active_purple   (matches L5+ A:Explore agent rows)
-    //   head_thinking → active_amber    (distinct from head_agent's purple)
+    // Decoupled from active_purple / active_amber / secondary so theme
+    // authors can tune the L1 AG: pill, [T] pill, and ledger TAG column
+    // without dragging the inherited tier along. Fallbacks in `build_palette`.
     pub tag_label: String,
     pub head_agent: String,
     pub head_thinking: String,
@@ -224,18 +220,11 @@ struct PresetColors {
     aurora_mid: Option<u8>,
     #[serde(default)]
     aurora_high: Option<u8>,
-    /// Ledger TAG column color (ENV / CTX / TOK / COST / TOOL / AGENT / TODO).
-    /// Falls back to `secondary` so the role can be tuned without dragging
-    /// L1 secondary text along with it.
+    /// Optional in JSON; fallbacks in `build_palette`.
     #[serde(default)]
     tag_label: Option<u8>,
-    /// L1 `AG:agent-name` color. Falls back to `active_purple` so it visually
-    /// rhymes with L5+ `A:Explore` agent rows (same concept, same color).
     #[serde(default)]
     head_agent: Option<u8>,
-    /// L1 `[T]` thinking pill color. Falls back to `active_amber` to keep it
-    /// distinct from `head_agent`'s purple (head_agent and head_thinking must
-    /// not collide on L1).
     #[serde(default)]
     head_thinking: Option<u8>,
 }
@@ -448,10 +437,8 @@ fn build_palette(preset: &PresetColors) -> ThemePalette {
         aurora_low: ansi256(preset.aurora_low.unwrap_or(preset.completed_check)),
         aurora_mid: ansi256(preset.aurora_mid.unwrap_or(preset.active_cyan)),
         aurora_high: ansi256(preset.aurora_high.unwrap_or(preset.active_coral)),
-        // Custom themes may omit HEAD/TAG fields → fall back to nearest tier:
-        //   tag_label     → secondary       (ledger TAG defaults to L1 secondary)
-        //   head_agent    → active_purple   (L1 AG: matches L5 A: rows)
-        //   head_thinking → active_amber    (distinct from agent purple)
+        // head_agent → active_purple keeps L1 AG: visually paired with L5 A: rows.
+        // head_thinking → active_amber must stay distinct from head_agent's purple.
         tag_label: ansi256(preset.tag_label.unwrap_or(preset.secondary)),
         head_agent: ansi256(preset.head_agent.unwrap_or(preset.active_purple)),
         head_thinking: ansi256(preset.head_thinking.unwrap_or(preset.active_amber)),
@@ -986,38 +973,35 @@ mod tests {
 
     // ── HEAD pills + ledger TAG palette fields ──
 
+    /// ANSI 256 cells within `MIN_ANSI_PERCEPTUAL_GAP` of each other are in
+    /// the same color family (e.g. 109/110 in Sky Blue) and read as the same
+    /// hue on most terminals.
+    const MIN_ANSI_PERCEPTUAL_GAP: u8 = 2;
+
+    fn for_each_builtin_palette(mut f: impl FnMut(&str, Option<&str>, ThemePalette)) {
+        for (name, _) in BUILTIN_THEMES {
+            for variant in [Some("dark"), Some("light")] {
+                f(
+                    name,
+                    variant,
+                    resolve_palette(name, variant, &ColorsConfig::default()),
+                );
+            }
+        }
+    }
+
     #[test]
     fn tokyo_night_authors_head_and_tag_fields_at_documented_fallbacks() {
         let p = resolve_palette("tokyo-night", Some("dark"), &ColorsConfig::default());
-        // tokyo-night.json explicitly authors these fields at the same values
-        // build_palette would fall back to (secondary 146, active_purple 183,
-        // active_amber 178). The explicit authoring documents intent — tokyo
-        // night is the reference theme and these are deliberately the
-        // canonical values for the role.
-        assert!(
-            p.tag_label.contains("146"),
-            "tag_label fallback to secondary"
-        );
-        assert!(
-            p.head_agent.contains("183"),
-            "head_agent fallback to active_purple"
-        );
-        assert!(
-            p.head_thinking.contains("178"),
-            "head_thinking fallback to active_amber"
-        );
+        assert!(p.tag_label.contains("146"));
+        assert!(p.head_agent.contains("183"));
+        assert!(p.head_thinking.contains("178"));
     }
 
     #[test]
     fn head_agent_and_head_thinking_distinct_in_default_palette() {
-        // head_agent borrows active_purple; head_thinking borrows active_amber.
-        // If a future change collapses them onto the same fallback, L1 will
-        // collide visually — fail loudly here so it's caught early.
         let p = ThemePalette::default();
-        assert_ne!(
-            p.head_agent, p.head_thinking,
-            "head_agent and head_thinking must render with distinct colors"
-        );
+        assert_ne!(p.head_agent, p.head_thinking);
     }
 
     #[test]
@@ -1037,48 +1021,29 @@ mod tests {
 
     #[test]
     fn every_builtin_theme_keeps_head_agent_distinct_from_head_thinking() {
-        // L1 collision regression: AG: pill and [T] pill must not share a
-        // color in any built-in theme, in either variant. If they collapsed,
-        // the two pills would visually merge on a busy L1.
-        for (name, _) in BUILTIN_THEMES {
-            for variant in [Some("dark"), Some("light")] {
-                let p = resolve_palette(name, variant, &ColorsConfig::default());
-                assert_ne!(
-                    p.head_agent, p.head_thinking,
-                    "theme {name} ({variant:?}) collapses head_agent and head_thinking onto the same color"
-                );
-            }
-        }
+        for_each_builtin_palette(|name, variant, p| {
+            assert_ne!(
+                p.head_agent, p.head_thinking,
+                "theme {name} ({variant:?}) collapses head_agent and head_thinking"
+            );
+        });
     }
 
     #[test]
     fn every_builtin_theme_keeps_head_agent_perceptually_apart_from_stable_blue() {
-        // L1 collision regression for the ORIGINAL S2 problem: M: pill (model
-        // identity, `stable_blue`) and AG: pill (`head_agent`) must not land
-        // on the same ANSI cell. ANSI 256 neighbours like 109/110 are within
-        // the same color family — perceptually indistinguishable on most
-        // terminals — so we additionally require that the two values aren't
-        // adjacent integers either.
-        for (name, _) in BUILTIN_THEMES {
-            for variant in [Some("dark"), Some("light")] {
-                let p = resolve_palette(name, variant, &ColorsConfig::default());
-                let stable = extract_ansi_code(&p.stable_blue).unwrap_or(0);
-                let head = extract_ansi_code(&p.head_agent).unwrap_or(0);
-                assert!(
-                    stable.abs_diff(head) > 1,
-                    "theme {name} ({variant:?}) has stable_blue={stable} \
-                     and head_agent={head} — too close to disambiguate \
-                     M: from AG: on L1"
-                );
-            }
-        }
+        for_each_builtin_palette(|name, variant, p| {
+            let stable = extract_ansi_code(&p.stable_blue).unwrap_or(0);
+            let head = extract_ansi_code(&p.head_agent).unwrap_or(0);
+            assert!(
+                stable.abs_diff(head) >= MIN_ANSI_PERCEPTUAL_GAP,
+                "theme {name} ({variant:?}) has stable_blue={stable} \
+                 and head_agent={head} — too close to disambiguate M: from AG: on L1"
+            );
+        });
     }
 
     #[test]
     fn tag_label_decouples_from_secondary_when_overridden() {
-        // Sanity for the role separation rationale: overriding tag_label must
-        // not move secondary, and overriding secondary must not move tag_label
-        // once it has its own value.
         let mut p = ThemePalette::default();
         let overrides = ColorsConfig {
             tag_label: Some(60),

--- a/src/render/frames/ledger.rs
+++ b/src/render/frames/ledger.rs
@@ -256,7 +256,7 @@ fn framed_tag_row(tag: &str, body: &str, ctx: &LedgerCtx) -> String {
         " ".repeat(TAG_COL_WIDTH)
     } else {
         let padded = format!("{tag:<width$}", tag = tag, width = TAG_WIDTH);
-        let coloured = colorize(&padded, &ctx.p.secondary, ctx.color);
+        let coloured = colorize(&padded, &ctx.p.tag_label, ctx.color);
         format!(
             "{}{}{}",
             " ".repeat(TAG_INDENT),

--- a/src/render/frames/shared.rs
+++ b/src/render/frames/shared.rs
@@ -219,12 +219,12 @@ pub fn identity_headline(
     if config.show_thinking && line1.thinking_enabled == Some(true) {
         // Label-only pill — no value; absent / `enabled: false` → omitted.
         let raw = glyph(config.glyph_mode, ICON_THINKING, "[T]");
-        parts.push(colorize(raw.trim_end(), &p.active_purple, color));
+        parts.push(colorize(raw.trim_end(), &p.head_thinking, color));
     }
 
     if config.show_agent {
         if let Some(name) = &line1.agent_name {
-            parts.push(colorize(name, &p.stable_blue, color));
+            parts.push(colorize(name, &p.head_agent, color));
         }
     }
 

--- a/src/render/layout.rs
+++ b/src/render/layout.rs
@@ -157,9 +157,6 @@ fn pane_config_from(config: &RenderConfig) -> PaneConfig {
             label: "Identity".to_string(),
             kinds: vec![LineKind::Identity],
         },
-        // ENV (was "Config") — aligns with the ledger TAG vocabulary
-        // ("ENV / CTX / TOK / COST / ...") and the underlying `EnvCollector`
-        // provider. Avoids confusion with `--print config` and pulseline.toml.
         PaneGroup {
             label: "ENV".to_string(),
             kinds: vec![LineKind::Config],

--- a/src/render/layout.rs
+++ b/src/render/layout.rs
@@ -157,8 +157,11 @@ fn pane_config_from(config: &RenderConfig) -> PaneConfig {
             label: "Identity".to_string(),
             kinds: vec![LineKind::Identity],
         },
+        // ENV (was "Config") — aligns with the ledger TAG vocabulary
+        // ("ENV / CTX / TOK / COST / ...") and the underlying `EnvCollector`
+        // provider. Avoids confusion with `--print config` and pulseline.toml.
         PaneGroup {
-            label: "Config".to_string(),
+            label: "ENV".to_string(),
             kinds: vec![LineKind::Config],
         },
         PaneGroup {
@@ -208,14 +211,14 @@ fn format_line1(frame: &RenderFrame, config: &RenderConfig, p: &ThemePalette) ->
         // Label-only pill — no value; `enabled: false` or missing → omitted entirely.
         // Trim before colorizing so the ANSI reset stays tight against the glyph.
         let raw = glyph(mode, ICON_THINKING, "[T]");
-        let label = colorize(raw.trim_end(), &p.active_purple, color);
+        let label = colorize(raw.trim_end(), &p.head_thinking, color);
         parts.push(label);
     }
 
     if config.show_agent {
         if let Some(agent_name) = &frame.line1.agent_name {
-            let label = colorize(&glyph(mode, ICON_AGENT, "AG:"), &p.stable_blue, color);
-            let val = colorize(agent_name, &p.stable_blue, color);
+            let label = colorize(&glyph(mode, ICON_AGENT, "AG:"), &p.head_agent, color);
+            let val = colorize(agent_name, &p.head_agent, color);
             parts.push(format!("{label}{val}"));
         }
     }

--- a/src/render/widgets/mod.rs
+++ b/src/render/widgets/mod.rs
@@ -47,6 +47,9 @@ pub(super) mod test_support {
             aurora_low: "LOW".to_string(),
             aurora_mid: "MID".to_string(),
             aurora_high: "HIGH".to_string(),
+            tag_label: String::new(),
+            head_agent: String::new(),
+            head_thinking: String::new(),
         }
     }
 }

--- a/src/themes/aburaya-twilight.json
+++ b/src/themes/aburaya-twilight.json
@@ -63,7 +63,11 @@
 
     "aurora_low": 67,
     "aurora_mid": 73,
-    "aurora_high": 210
+    "aurora_high": 210,
+
+    "tag_label":     109,
+    "head_agent":    97,
+    "head_thinking": 220
   },
 
   "light_emphasis": {
@@ -75,7 +79,8 @@
     "strata_activity": 247,
     "aurora_low": 67,
     "aurora_mid": 73,
-    "aurora_high": 210
+    "aurora_high": 210,
+    "tag_label": 241
   },
 
   "design_notes": {

--- a/src/themes/cnc-telemetry.json
+++ b/src/themes/cnc-telemetry.json
@@ -63,7 +63,11 @@
 
     "aurora_low":          109,
     "aurora_mid":          66,
-    "aurora_high":         130
+    "aurora_high":         130,
+
+    "tag_label":           240,
+    "head_agent":          66,
+    "head_thinking":       130
   },
 
   "light_emphasis": {
@@ -75,7 +79,8 @@
     "strata_activity": 245,
     "aurora_low": 109,
     "aurora_mid": 66,
-    "aurora_high": 130
+    "aurora_high": 130,
+    "tag_label": 241
   },
 
   "usage_logic": {

--- a/src/themes/cyberdeck-hud.json
+++ b/src/themes/cyberdeck-hud.json
@@ -63,7 +63,11 @@
 
     "aurora_low":          60,
     "aurora_mid":          51,
-    "aurora_high":         208
+    "aurora_high":         208,
+
+    "tag_label":           243,
+    "head_agent":          51,
+    "head_thinking":       208
   },
 
   "light_emphasis": {
@@ -75,7 +79,8 @@
     "strata_activity": 245,
     "aurora_low": 60,
     "aurora_mid": 51,
-    "aurora_high": 208
+    "aurora_high": 208,
+    "tag_label": 240
   },
 
   "usage_logic": {

--- a/src/themes/echo-sub-zero.json
+++ b/src/themes/echo-sub-zero.json
@@ -63,7 +63,11 @@
 
     "aurora_low":          108,
     "aurora_mid":          114,
-    "aurora_high":         191
+    "aurora_high":         191,
+
+    "tag_label":           244,
+    "head_agent":          110,
+    "head_thinking":       191
   },
 
   "light_emphasis": {
@@ -75,7 +79,8 @@
     "strata_activity": 248,
     "aurora_low": 108,
     "aurora_mid": 114,
-    "aurora_high": 191
+    "aurora_high": 191,
+    "tag_label": 241
   },
 
   "usage_logic": {

--- a/src/themes/echo-sub-zero.json
+++ b/src/themes/echo-sub-zero.json
@@ -66,7 +66,7 @@
     "aurora_high":         191,
 
     "tag_label":           244,
-    "head_agent":          110,
+    "head_agent":          174,
     "head_thinking":       191
   },
 

--- a/src/themes/mako-reactor.json
+++ b/src/themes/mako-reactor.json
@@ -63,7 +63,11 @@
 
     "aurora_low": 60,
     "aurora_mid": 43,
-    "aurora_high": 220
+    "aurora_high": 220,
+
+    "tag_label":     244,
+    "head_agent":    135,
+    "head_thinking": 220
   },
 
   "light_emphasis": {
@@ -75,7 +79,8 @@
     "strata_activity": 245,
     "aurora_low": 60,
     "aurora_mid": 43,
-    "aurora_high": 220
+    "aurora_high": 220,
+    "tag_label": 238
   },
 
   "design_notes": {

--- a/src/themes/matte-carbon-neon.json
+++ b/src/themes/matte-carbon-neon.json
@@ -63,7 +63,11 @@
 
     "aurora_low": 240,
     "aurora_mid": 51,
-    "aurora_high": 196
+    "aurora_high": 196,
+
+    "tag_label":     240,
+    "head_agent":    135,
+    "head_thinking": 226
   },
 
   "light_emphasis": {
@@ -75,7 +79,8 @@
     "strata_activity": 247,
     "aurora_low": 240,
     "aurora_mid": 51,
-    "aurora_high": 196
+    "aurora_high": 196,
+    "tag_label": 239
   },
 
   "design_notes": {

--- a/src/themes/matte-carbon-neon.json
+++ b/src/themes/matte-carbon-neon.json
@@ -66,7 +66,7 @@
     "aurora_high": 196,
 
     "tag_label":     240,
-    "head_agent":    135,
+    "head_agent":    141,
     "head_thinking": 226
   },
 

--- a/src/themes/pulseline-aurora.json
+++ b/src/themes/pulseline-aurora.json
@@ -51,7 +51,11 @@
 
     "aurora_low":          73,
     "aurora_mid":          80,
-    "aurora_high":         209
+    "aurora_high":         209,
+
+    "tag_label":           244,
+    "head_agent":          80,
+    "head_thinking":       178
   },
 
   "light_emphasis": {
@@ -63,7 +67,8 @@
     "strata_activity": 246,
     "aurora_low":  73,
     "aurora_mid":  80,
-    "aurora_high": 209
+    "aurora_high": 209,
+    "tag_label":   240
   },
 
   "design_notes": {

--- a/src/themes/stark-hud.json
+++ b/src/themes/stark-hud.json
@@ -63,7 +63,11 @@
 
     "aurora_low": 59,
     "aurora_mid": 74,
-    "aurora_high": 214
+    "aurora_high": 214,
+
+    "tag_label":     240,
+    "head_agent":    141,
+    "head_thinking": 214
   },
 
   "light_emphasis": {
@@ -75,7 +79,8 @@
     "strata_activity": 245,
     "aurora_low": 59,
     "aurora_mid": 74,
-    "aurora_high": 214
+    "aurora_high": 214,
+    "tag_label": 238
   },
 
   "design_notes": {

--- a/src/themes/titanium-precision.json
+++ b/src/themes/titanium-precision.json
@@ -63,7 +63,11 @@
 
     "aurora_low":          67,
     "aurora_mid":          74,
-    "aurora_high":         167
+    "aurora_high":         167,
+
+    "tag_label":           240,
+    "head_agent":          74,
+    "head_thinking":       136
   },
 
   "light_emphasis": {
@@ -75,7 +79,8 @@
     "strata_activity": 247,
     "aurora_low": 67,
     "aurora_mid": 74,
-    "aurora_high": 167
+    "aurora_high": 167,
+    "tag_label": 240
   },
 
   "usage_logic": {

--- a/src/themes/tokyo-night.json
+++ b/src/themes/tokyo-night.json
@@ -63,7 +63,11 @@
 
     "aurora_low":          73,
     "aurora_mid":          80,
-    "aurora_high":         209
+    "aurora_high":         209,
+
+    "tag_label":           146,
+    "head_agent":          183,
+    "head_thinking":       178
   },
 
   "light_emphasis": {
@@ -75,7 +79,8 @@
     "strata_activity": 246,
     "aurora_low": 73,
     "aurora_mid": 80,
-    "aurora_high": 209
+    "aurora_high": 209,
+    "tag_label": 240
   },
 
   "element_mapping": {

--- a/tests/agent_worktree.rs
+++ b/tests/agent_worktree.rs
@@ -96,12 +96,7 @@ fn agent_hidden_when_toggle_off() {
 
 #[test]
 fn agent_pill_uses_head_agent_color_distinct_from_model() {
-    // Regression test for the head_agent palette field (commit b of the
-    // HEAD-pills cleanup). Before the rewire, AG: borrowed `stable_blue`
-    // — same as `M:` — making the two pills indistinguishable on L1.
-    // The rewire routes AG: through `head_agent` (default fallback:
-    // active_purple). If a future change collapses head_agent back onto
-    // stable_blue, this test fails.
+    // Guards against AG: collapsing back onto `stable_blue` (the M: color).
     let payload = make_payload_with_agent("code-reviewer");
     let frame = RenderFrame::from_payload(&payload);
     let config = RenderConfig {
@@ -112,9 +107,7 @@ fn agent_pill_uses_head_agent_color_distinct_from_model() {
     let lines = cc_pulseline::render::layout::render_frame(&frame, &config);
     let l1 = &lines[0];
 
-    // Default theme (tokyo-night dark): stable_blue=111, head_agent=183.
-    // Both pills carry an ANSI prefix `\x1b[38;5;<code>m` directly before
-    // their label glyph.
+    // tokyo-night dark: stable_blue=111, head_agent=183.
     let m_idx = l1.find("M:").expect("M: pill present");
     let ag_idx = l1.find("AG:").expect("AG: pill present");
     let m_prefix = &l1[..m_idx];
@@ -131,9 +124,8 @@ fn agent_pill_uses_head_agent_color_distinct_from_model() {
 
 #[test]
 fn console_title_agent_uses_head_agent_color() {
-    // identity_headline (used by Console / Ledger to hoist Identity into
-    // the frame title) had its own copy of the agent color path. This
-    // test guards that path from re-borrowing `stable_blue`.
+    // Console / Ledger hoist Identity into the frame title via a separate
+    // formatter (`identity_headline`); guard that path too.
     use cc_pulseline::config::GlyphMode;
     use cc_pulseline::render::pane::{LayoutStyle, PaneWidth};
 
@@ -149,9 +141,6 @@ fn console_title_agent_uses_head_agent_color() {
     };
     let lines = cc_pulseline::render::layout::render_frame(&frame, &config);
     let title = &lines[0];
-
-    // tokyo-night: stable_blue=111, head_agent=183. Title must NOT contain
-    // a stable_blue ANSI prefix immediately before the agent name.
     let agent_idx = title.find("design-advisor").expect("agent name in title");
     let prefix = &title[..agent_idx];
     assert!(

--- a/tests/agent_worktree.rs
+++ b/tests/agent_worktree.rs
@@ -94,6 +94,41 @@ fn agent_hidden_when_toggle_off() {
     );
 }
 
+#[test]
+fn agent_pill_uses_head_agent_color_distinct_from_model() {
+    // Regression test for the head_agent palette field (commit b of the
+    // HEAD-pills cleanup). Before the rewire, AG: borrowed `stable_blue`
+    // — same as `M:` — making the two pills indistinguishable on L1.
+    // The rewire routes AG: through `head_agent` (default fallback:
+    // active_purple). If a future change collapses head_agent back onto
+    // stable_blue, this test fails.
+    let payload = make_payload_with_agent("code-reviewer");
+    let frame = RenderFrame::from_payload(&payload);
+    let config = RenderConfig {
+        show_agent: true,
+        color_enabled: true,
+        ..Default::default()
+    };
+    let lines = cc_pulseline::render::layout::render_frame(&frame, &config);
+    let l1 = &lines[0];
+
+    // Default theme (tokyo-night dark): stable_blue=111, head_agent=183.
+    // Both pills carry an ANSI prefix `\x1b[38;5;<code>m` directly before
+    // their label glyph.
+    let m_idx = l1.find("M:").expect("M: pill present");
+    let ag_idx = l1.find("AG:").expect("AG: pill present");
+    let m_prefix = &l1[..m_idx];
+    let ag_prefix = &l1[..ag_idx];
+    assert!(
+        m_prefix.ends_with("\x1b[38;5;111m"),
+        "M: should be stable_blue (111); got prefix: {m_prefix:?}"
+    );
+    assert!(
+        ag_prefix.ends_with("\x1b[38;5;183m"),
+        "AG: should be head_agent (default 183, active_purple); got prefix: {ag_prefix:?}"
+    );
+}
+
 // ── Worktree tests ───────────────────────────────────────────────────
 
 #[test]

--- a/tests/agent_worktree.rs
+++ b/tests/agent_worktree.rs
@@ -129,6 +129,37 @@ fn agent_pill_uses_head_agent_color_distinct_from_model() {
     );
 }
 
+#[test]
+fn console_title_agent_uses_head_agent_color() {
+    // identity_headline (used by Console / Ledger to hoist Identity into
+    // the frame title) had its own copy of the agent color path. This
+    // test guards that path from re-borrowing `stable_blue`.
+    use cc_pulseline::config::GlyphMode;
+    use cc_pulseline::render::pane::{LayoutStyle, PaneWidth};
+
+    let payload = make_payload_with_agent("design-advisor");
+    let frame = RenderFrame::from_payload(&payload);
+    let config = RenderConfig {
+        show_agent: true,
+        color_enabled: true,
+        glyph_mode: GlyphMode::Ascii,
+        pane_style: LayoutStyle::Console,
+        pane_width_mode: PaneWidth::Auto,
+        ..Default::default()
+    };
+    let lines = cc_pulseline::render::layout::render_frame(&frame, &config);
+    let title = &lines[0];
+
+    // tokyo-night: stable_blue=111, head_agent=183. Title must NOT contain
+    // a stable_blue ANSI prefix immediately before the agent name.
+    let agent_idx = title.find("design-advisor").expect("agent name in title");
+    let prefix = &title[..agent_idx];
+    assert!(
+        prefix.ends_with("\x1b[38;5;183m"),
+        "console title agent name should be head_agent (183); got prefix: {prefix:?}"
+    );
+}
+
 // ── Worktree tests ───────────────────────────────────────────────────
 
 #[test]

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -73,7 +73,7 @@ fn version_flag_shows_version() {
         stdout.contains("cc-pulseline"),
         "should contain binary name"
     );
-    assert!(stdout.contains("1.1.0"), "should contain version number");
+    assert!(stdout.contains("1.1.1"), "should contain version number");
 }
 
 #[test]
@@ -86,7 +86,7 @@ fn short_version_flag_works() {
     assert!(output.status.success(), "should exit 0");
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(
-        stdout.contains("cc-pulseline 1.1.0"),
+        stdout.contains("cc-pulseline 1.1.1"),
         "should show name and version"
     );
 }

--- a/tests/pane_rendering.rs
+++ b/tests/pane_rendering.rs
@@ -17,8 +17,10 @@ fn base_config(style: LayoutStyle) -> PaneConfig {
                 label: "Identity".into(),
                 kinds: vec![LineKind::Identity],
             },
+            // Mirrors the production label in `pane_config_from`: ENV (was "Config"
+            // before alignment with the ledger TAG vocabulary).
             PaneGroup {
-                label: "Config".into(),
+                label: "ENV".into(),
                 kinds: vec![LineKind::Config],
             },
             PaneGroup {
@@ -60,7 +62,7 @@ fn grid_adds_label_column_with_divider_and_aligned_content() {
         out[0]
     );
     assert!(
-        out[1].starts_with("Config    │"),
+        out[1].starts_with("ENV       │"),
         "second row aligns label to same width; got: {:?}",
         out[1]
     );
@@ -176,7 +178,7 @@ fn sections_wraps_once_with_separator_between_every_group() {
     assert!(out[0].starts_with('╭'));
     assert!(out[1].starts_with("│ Identity"));
     assert!(out[2].starts_with('├'));
-    assert!(out[3].starts_with("│ Config"));
+    assert!(out[3].starts_with("│ ENV"));
     assert!(out[4].starts_with('├'));
     assert!(out[5].starts_with("│ Budget"));
     assert!(out[6].starts_with('├'));

--- a/tests/pane_rendering.rs
+++ b/tests/pane_rendering.rs
@@ -17,8 +17,6 @@ fn base_config(style: LayoutStyle) -> PaneConfig {
                 label: "Identity".into(),
                 kinds: vec![LineKind::Identity],
             },
-            // Mirrors the production label in `pane_config_from`: ENV (was "Config"
-            // before alignment with the ledger TAG vocabulary).
             PaneGroup {
                 label: "ENV".into(),
                 kinds: vec![LineKind::Config],


### PR DESCRIPTION
## Summary

Three palette roles (`AG:` agent pill, `[T]` thinking pill, ledger TAG column) were borrowing colors from existing tiers (`stable_blue`, `active_purple`, `secondary`). This coupled layout-specific roles to general-purpose tiers — themers couldn't tune one without dragging the other along, and `M:` and `AG:` collided on L1 because both pulled from `stable_blue`.

This PR introduces three new `ThemePalette` slots (`tag_label`, `head_agent`, `head_thinking`), rewires the renderers, designs intentional values for each of the 10 built-in themes, and adds catch-net tests against future regression.

Also renames the macro 4-group label `Config` → `ENV` so the zones / grid / sections / console layouts use the same vocabulary as ledger's TAG column.

## Why

- L1 collision: `M:Opus | AG:greg-bot` both rendered as the same `stable_blue` — visually indistinguishable.
- Theme authors couldn't move the `[T]` pill without also moving every L5+ `A:Explore` row (both pulled from `active_purple`).
- Ledger TAG column borrowed `secondary` (the L1 secondary text tier), so any TAG tuning dragged the rest of L1 along.
- The macro group label `Config` clashed with `--print config` and `pulseline.toml`; the underlying provider has always been `EnvCollector`.

Same pattern as the prior `strata_*` and `aurora_*` extensions: when a layout introduces a new structural role, give it its own palette slot with a sensible fallback.

## What changed

5 commits, deliberately split for review:

| commit | scope |
|---|---|
| `90986ee` | palette schema — add `tag_label` / `head_agent` / `head_thinking` fields, fallbacks, overrides; zero visual change |
| `39c155b` | rewire `format_line1`, `identity_headline`, ledger TAG; rename `Config` → `ENV` |
| `2cfcf28` | per-theme designed values for all 10 built-in themes + drive-by fix to `identity_headline` |
| `5ce9728` | review fixes — `--palette-map` Heads & Tag section, M:/AG: catch-net, echo-sub-zero collision (109/110 → 109/174), mako/matte differentiation (135 vs 141) |
| `9d3c4df` | /simplify pass — drop comment rot, name `MIN_ANSI_PERCEPTUAL_GAP`, extract `for_each_builtin_palette` test helper |

### Per-theme `head_agent` / `head_thinking` / `tag_label`

| theme | tag | agent | thinking |
|---|---:|---:|---:|
| tokyo-night | 146 | 183 | 178 |
| aburaya-twilight | 109 | 97 | 220 |
| cnc-telemetry | 240 | 66 | 130 |
| cyberdeck-hud | 243 | 51 | 208 |
| echo-sub-zero | 244 | 174 | 191 |
| mako-reactor | 244 | 135 | 220 |
| matte-carbon-neon | 240 | 141 | 226 |
| pulseline-aurora | 244 | 80 | 178 |
| stark-hud | 240 | 141 | 214 |
| titanium-precision | 240 | 74 | 136 |

Mono-accent themes preserve their contract on the activity tier; head_agent on L1 is a separate role and intentionally diverges where needed (echo-sub-zero, cnc, cyberdeck, pulseline-aurora, titanium).

## Test plan

- [ ] `cargo test` — 30 test groups, includes 5 new tests
  - `tokyo_night_authors_head_and_tag_fields_at_documented_fallbacks`
  - `apply_overrides_patches_head_and_tag_fields`
  - `tag_label_decouples_from_secondary_when_overridden`
  - `every_builtin_theme_keeps_head_agent_distinct_from_head_thinking` (catch-net)
  - `every_builtin_theme_keeps_head_agent_perceptually_apart_from_stable_blue` (catch-net)
  - `agent_pill_uses_head_agent_color_distinct_from_model` (regression)
  - `console_title_agent_uses_head_agent_color` (regression for `identity_headline` path)
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --check` — clean
- [ ] Smoke: `cargo run --release -- --palette-map <theme>` — confirms `Heads & Tag` section renders for every theme
- [ ] Smoke: `cargo run --release -- --preview` — visual sanity check across all 10 themes
- [ ] Backward compat: custom themes in `~/.claude/pulseline/themes/*.json` without the new fields still load via documented fallbacks (`secondary` / `active_purple` / `active_amber`)

## Design doc

`designs/palette-head-fields-review.md` — captures the original critique, Round 2 decision rationale, and the per-theme design table.