### PR TITLE
Release 1.1.2: render CC: version pill in ledger identity headline

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "pulseline",
       "description": "Setup and manage the cc-pulseline statusline — install binary, configure display, and diagnose issues",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "source": ".",
       "category": "productivity"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pulseline",
   "description": "High-performance multi-line statusline for Claude Code with setup commands and diagnostics",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": {
     "name": "cc-pulseline"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2026-05-07
+
+Render the Claude Code version pill (`CC:`) in the ledger layout's identity
+headline. Other layouts already honored the `show_version` toggle via
+`render::layout::format_line1`; ledger had a parallel render path
+(`identity_headline` in `render/frames/shared.rs`) that was missing the
+branch, so flipping `show_version` was a no-op for ledger users.
+
+### Added
+
+- **`CC:` pill in ledger identity headline** — Wires `show_version`
+  through `identity_headline` so the ledger top-frame title now shows
+  `CC:{version}` before the model name, using the same icon (`ICON_VERSION`)
+  and `secondary` palette tier as the non-ledger layouts.
+
 ## [1.1.1] - 2026-05-01
 
 Decouple the L1 HEAD pills (`AG:` agent, `[T]` thinking) and the ledger
@@ -343,6 +358,7 @@ collision on L1 is fixed in every built-in theme.
 - **Context alert thresholds** at 70%/55% — warnings appear before Claude Code's ~80% auto-compact triggers
 - **Steel blue completed checkmarks** — distinct from plan-mode green to avoid visual collision
 
+[1.1.2]: https://github.com/GregoryHo/cc-pulseline/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/GregoryHo/cc-pulseline/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/GregoryHo/cc-pulseline/compare/v1.0.6...v1.1.0
 [1.0.6]: https://github.com/GregoryHo/cc-pulseline/compare/v1.0.5...v1.0.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc-pulseline"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "criterion",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc-pulseline"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 rust-version = "1.85"
 description = "High-performance multi-line statusline for Claude Code with deep observability"

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Recognized widgets: `gauge`, `sparkline`, `text` for context; `gauge`, `text` fo
 ## CLI Usage
 
 ```
-cc-pulseline 1.1.1 - High-performance Claude Code statusline
+cc-pulseline 1.1.2 - High-performance Claude Code statusline
 
 USAGE:
     cc-pulseline [OPTIONS]

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -184,7 +184,7 @@ ledger. Each metric occupies its own row, prefixed by a 6-char TAG; blank
 rows separate logical groups. Tallest layout.
 
 ```
-╭─ Opus 4.6 · ~/cc-pulseline · feat/status-pane* ↑21 ─────────────────────╮
+╭─ CC:2.1.119 · Opus 4.6 · ~/cc-pulseline · feat/status-pane* ↑21 ────────╮
 │                                                                         │
 │  ENV     󰈙 2 CLAUDE.md   󰱇 10 rules   󰧜 4 memories   󱭧 36 hooks        │
 │                                                                         │

--- a/src/render/frames/shared.rs
+++ b/src/render/frames/shared.rs
@@ -16,7 +16,7 @@ use std::ops::Range;
 use crate::config::{GlyphMode, RenderConfig};
 use crate::render::color::{colorize, visible_width, ThemePalette};
 use crate::render::fmt::format_number;
-use crate::render::icons::{glyph, ICON_EFFORT, ICON_THINKING};
+use crate::render::icons::{glyph, ICON_EFFORT, ICON_THINKING, ICON_VERSION};
 use crate::render::layout;
 use crate::render::pane::{LineKind, PaneConfig, PaneGroup};
 use crate::render::widgets;
@@ -198,6 +198,15 @@ pub fn identity_headline(
     let color = config.color_enabled;
     let coloured_sep = colorize(separator, &p.structural, color);
     let mut parts: Vec<String> = Vec::new();
+
+    if config.show_version {
+        let raw = format!(
+            "{}{}",
+            glyph(config.glyph_mode, ICON_VERSION, "CC:"),
+            line1.claude_code_version
+        );
+        parts.push(colorize(&raw, &p.secondary, color));
+    }
 
     if config.show_model {
         parts.push(colorize(&line1.model, &p.primary, color));

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -73,7 +73,7 @@ fn version_flag_shows_version() {
         stdout.contains("cc-pulseline"),
         "should contain binary name"
     );
-    assert!(stdout.contains("1.1.1"), "should contain version number");
+    assert!(stdout.contains("1.1.2"), "should contain version number");
 }
 
 #[test]
@@ -86,7 +86,7 @@ fn short_version_flag_works() {
     assert!(output.status.success(), "should exit 0");
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(
-        stdout.contains("cc-pulseline 1.1.1"),
+        stdout.contains("cc-pulseline 1.1.2"),
         "should show name and version"
     );
 }


### PR DESCRIPTION
## Summary

- Render `CC:{version}` pill in the ledger layout's identity headline (`identity_headline` in `render/frames/shared.rs`) — other layouts already honored `show_version`; ledger had a parallel render path that was missing the branch.
- Bump version `1.1.1` → `1.1.2` across the 6 known sites (Cargo.toml/lock, plugin.json, marketplace.json, README CLI banner, cli_flags.rs assertions).
- Refresh ledger headline example in `docs/layouts.md` to include the new `CC:` prefix.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 30 suites all green, 0 FAILED
- [x] `cargo build --release` succeeds
- [x] `./target/release/cc-pulseline --version` prints `cc-pulseline 1.1.2`
- [x] Smoke render emits ANSI output with the new `CC:` pill before the model name in ledger top-frame title