### PR TITLE
Release 1.1.3: ledger headline overflow + width-detection fallback

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "pulseline",
       "description": "Setup and manage the cc-pulseline statusline — install binary, configure display, and diagnose issues",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "source": ".",
       "category": "productivity"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pulseline",
   "description": "High-performance multi-line statusline for Claude Code with setup commands and diagnostics",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": {
     "name": "cc-pulseline"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2026-05-12
+
+Patch release fixing two ledger-rendering bugs exposed by the v1.1.2 `CC:`
+pill addition: a top-frame border misalignment under long path/branch, and
+a silent fallback from ledger to Console layout when terminal-width
+detection fails (the common case in the Claude Code statusline hook
+context).
+
+### Fixed
+
+- **Ledger top-frame border misalignment** — When the identity headline
+  exceeded the inner frame width, the trailing-dashes math used
+  `saturating_sub`, which kept the right corner `╮` visually but did not
+  truncate the headline itself; the result was a `╮` pushed past the body
+  rows. `top_frame` now caps the headline via `identity_headline_bounded`
+  (drops optional pills in `version → git_stats → worktree → effort →
+  agent → thinking` order), then compresses `project_path` and
+  `git_branch` with segment-aware ellipsis (`{first}/…/{last}` →
+  `…/{last}` → `keep_tail`), with `truncate_to_width` as a final safety
+  net.
+- **Ledger silently downgrading to Console layout** — When
+  `terminal_width` detection failed (statusline hook context with no
+  accessible `/dev/tty` and `COLUMNS=0` or unset), ledger fell back to
+  Console (sections-style with `├─┼─┤` row separators and `│ TAG │ body │`
+  cell borders) — but the hook context is the common-case invocation, so
+  users were losing their chosen `ledger` layout silently. The renderer
+  now assumes `pane_max_width` (default 140) when detection fails; only
+  an *observed* width below 90 still triggers Console fallback.
+- **`resolve_terminal_width` accepts `COLUMNS="0"` as a valid width** —
+  Both the env-var branch and the ioctl branch now reject 0, falling
+  through cleanly so the function returns `None` when no usable width
+  exists.
+
+### Internal
+
+- **`compress_path_segments`** (`render/activity/truncate.rs`) — New
+  helper that retains the leaf segment and progressively drops the
+  middle (`{first}/…/{last}` → `…/{last}` → `keep_tail`). Char-safe; used
+  by ledger's `top_frame` overflow cascade for both project paths and
+  branch names containing `/`.
+- **`identity_headline_bounded`** (`render/frames/shared.rs`) — Width-aware
+  wrapper around `identity_headline` that progressively turns off
+  optional pills until the rendered width fits. Mirrors `config_row`'s
+  clone-mutate-remeasure pattern; never mutates `Line1Metrics`.
+- **Doc-rot fix**: `docs/theme-palette.md` Tier Summary header updated
+  from "31 unique fields" to "34 unique fields" to match the current
+  `ThemePalette` struct (drift from 1.1.1's `tag_label` / `head_agent` /
+  `head_thinking` additions).
+
 ## [1.1.2] - 2026-05-07
 
 Render the Claude Code version pill (`CC:`) in the ledger layout's identity
@@ -358,6 +407,7 @@ collision on L1 is fixed in every built-in theme.
 - **Context alert thresholds** at 70%/55% — warnings appear before Claude Code's ~80% auto-compact triggers
 - **Steel blue completed checkmarks** — distinct from plan-mode green to avoid visual collision
 
+[1.1.3]: https://github.com/GregoryHo/cc-pulseline/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/GregoryHo/cc-pulseline/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/GregoryHo/cc-pulseline/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/GregoryHo/cc-pulseline/compare/v1.0.6...v1.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc-pulseline"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "criterion",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc-pulseline"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 rust-version = "1.85"
 description = "High-performance multi-line statusline for Claude Code with deep observability"

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Recognized widgets: `gauge`, `sparkline`, `text` for context; `gauge`, `text` fo
 ## CLI Usage
 
 ```
-cc-pulseline 1.1.2 - High-performance Claude Code statusline
+cc-pulseline 1.1.3 - High-performance Claude Code statusline
 
 USAGE:
     cc-pulseline [OPTIONS]

--- a/docs/theme-palette.md
+++ b/docs/theme-palette.md
@@ -145,7 +145,7 @@ For backward compatibility, old names map to the new tier system:
 
 **Removed**: `PROJECT_CYAN` (51), `COST_GOLD` (220), `RATE_YELLOW` (226) -- replaced by emphasis tiers and rate-based cost coloring.
 
-## Tier Summary (8 types, 31 unique fields)
+## Tier Summary (8 types, 34 unique fields)
 
 | Tier | Colors | Purpose | Status |
 |------|--------|---------|--------|

--- a/src/config.rs
+++ b/src/config.rs
@@ -1294,10 +1294,12 @@ fn parse_pane_width_mode(value: &str, fixed_width: Option<usize>) -> PaneWidth {
 fn resolve_terminal_width(columns_env: Option<&str>, ioctl_probe: Option<u16>) -> Option<usize> {
     if let Some(raw) = columns_env {
         if let Ok(w) = raw.parse::<usize>() {
-            return Some(w);
+            if w > 0 {
+                return Some(w);
+            }
         }
     }
-    ioctl_probe.map(|w| w as usize)
+    ioctl_probe.map(|w| w as usize).filter(|w| *w > 0)
 }
 
 /// Two-stage ioctl probe: first try the inherited stdio fds via
@@ -1447,5 +1449,22 @@ mod terminal_width_tests {
     fn returns_none_when_both_sources_fail() {
         assert_eq!(resolve_terminal_width(None, None), None);
         assert_eq!(resolve_terminal_width(Some("bogus"), None), None);
+    }
+
+    #[test]
+    fn columns_env_zero_falls_through_to_ioctl() {
+        // Background shells / statusline hook contexts can inherit `COLUMNS=0`;
+        // treat it as "unknown" so ioctl probe gets a chance.
+        assert_eq!(resolve_terminal_width(Some("0"), Some(160)), Some(160));
+    }
+
+    #[test]
+    fn columns_env_zero_with_no_ioctl_yields_none() {
+        assert_eq!(resolve_terminal_width(Some("0"), None), None);
+    }
+
+    #[test]
+    fn ioctl_zero_treated_as_none() {
+        assert_eq!(resolve_terminal_width(None, Some(0)), None);
     }
 }

--- a/src/render/activity/truncate.rs
+++ b/src/render/activity/truncate.rs
@@ -112,6 +112,53 @@ pub fn keep_middle(raw: &str, max_chars: usize) -> String {
     )
 }
 
+/// Segment-aware path compression for `/`-delimited paths.
+///
+/// Preserves the first and last segments (most informative), replacing
+/// middle segments with a single `…`. Three-stage cascade:
+///   1. Try `{first}/…/{last}`.
+///   2. If too wide, drop the first segment: `…/{last}`.
+///   3. If the leaf alone is too wide, truncate it with `keep_tail`.
+///
+/// Falls back to `keep_tail` for paths with 0 or 1 segments (no
+/// middle to elide). Char-safe — uses `chars()` for width math.
+///
+/// Examples (max_width=24):
+///   `~/Workspace/Paradise/Frontend/platform-1.0/platform-web`
+///     → `~/…/platform-web` (16 chars) when middle elision suffices
+///   `/very/deep/nested/path/extremely_long_filename.rs`
+///     → `…/extremely_long_filena…` when leaf needs truncation too
+pub fn compress_path_segments(path: &str, max_width: usize) -> String {
+    let count = path.chars().count();
+    if count <= max_width {
+        return path.to_string();
+    }
+    if max_width == 0 {
+        return String::new();
+    }
+    let segments: Vec<&str> = path.split('/').collect();
+    if segments.len() < 3 {
+        // 0, 1, or 2 segments: no middle to elide. Fall back to keep_tail.
+        return keep_tail(path, max_width);
+    }
+    let first = segments.first().copied().unwrap_or("");
+    let last = segments.last().copied().unwrap_or("");
+    let first_w = first.chars().count();
+    let last_w = last.chars().count();
+    // Stage 1: `{first}/…/{last}` — needs first + 3 (for `/…/`) + last chars.
+    let stage1_w = first_w + 3 + last_w;
+    if stage1_w <= max_width {
+        return format!("{first}/{ELLIPSIS}/{last}");
+    }
+    // Stage 2: `…/{last}` — needs 2 + last chars.
+    let stage2_w = 2 + last_w;
+    if stage2_w <= max_width {
+        return format!("{ELLIPSIS}/{last}");
+    }
+    // Stage 3: leaf alone is too long; truncate it.
+    keep_tail(last, max_width)
+}
+
 /// Truncate at a word boundary: never cut mid-word. If the first word is
 /// itself longer than `max_chars`, falls back to `keep_head` so we still
 /// emit something. Words are space-separated.
@@ -339,6 +386,69 @@ mod tests {
     #[test]
     fn keep_middle_short_returns_intact() {
         assert_eq!(keep_middle("hello", 10), "hello");
+    }
+
+    #[test]
+    fn compress_path_short_returns_intact() {
+        assert_eq!(
+            compress_path_segments("~/repo/file.rs", 30),
+            "~/repo/file.rs"
+        );
+    }
+    #[test]
+    fn compress_path_elides_middle_segments() {
+        // 55 chars in, max=24, segments=5; stage 1: `~` (1) + `/…/` (3) + `platform-web` (12) = 16
+        assert_eq!(
+            compress_path_segments(
+                "~/Workspace/Paradise/Frontend/platform-1.0/platform-web",
+                24
+            ),
+            "~/\u{2026}/platform-web"
+        );
+    }
+    #[test]
+    fn compress_path_drops_first_when_too_long() {
+        // first segment alone (`very-long-org-prefix`) is 20 chars, plus `/…/leaf` (8)
+        // = 28 > 24. Stage 2: `…/leaf` = 6 chars, fits.
+        assert_eq!(
+            compress_path_segments("very-long-org-prefix/mid/leaf", 10),
+            "\u{2026}/leaf"
+        );
+    }
+    #[test]
+    fn compress_path_truncates_leaf_when_alone_too_long() {
+        let result = compress_path_segments("a/b/extremely_long_filename_here.rs", 10);
+        assert!(result.chars().count() <= 10);
+        // Either `.../leaf` (when leaf fits with prefix) or a truncated leaf.
+        assert!(result.contains('\u{2026}') || result.starts_with("..."));
+    }
+    #[test]
+    fn compress_path_single_segment_falls_back_to_keep_tail() {
+        // No `/` separators — delegates to keep_tail, which uses leading ellipsis.
+        let result = compress_path_segments("supercalifragilisticexpialidocious", 10);
+        assert!(result.chars().count() <= 10);
+        assert!(result.starts_with('\u{2026}'));
+    }
+    #[test]
+    fn compress_path_two_segments_falls_back_to_keep_tail() {
+        // 2 segments — keep_tail tries `.../{leaf}`. `~/very-long-leaf` (16) > 10.
+        // keep_tail's path branch tries `.../very-long-leaf` (18) > 10, leaf alone
+        // (14) > 10, falls back to keep_head(leaf, 10) = "very-long…"
+        let result = compress_path_segments("~/very-long-leaf", 10);
+        assert!(result.chars().count() <= 10);
+    }
+    #[test]
+    fn compress_path_branch_with_slashes_works() {
+        // Branches like `feature/e2e-traceability-rollout-integration` have one
+        // `/` — that's 2 segments, falls back to keep_tail.
+        let result = compress_path_segments("feature/e2e-traceability-rollout-integration", 16);
+        assert!(result.chars().count() <= 16);
+    }
+    #[test]
+    fn compress_path_unicode_safe() {
+        // 多段 unicode path
+        let result = compress_path_segments("~/工作區/前端/平台/網頁", 8);
+        assert!(result.chars().count() <= 8);
     }
 
     #[test]

--- a/src/render/activity/truncate.rs
+++ b/src/render/activity/truncate.rs
@@ -145,17 +145,12 @@ pub fn compress_path_segments(path: &str, max_width: usize) -> String {
     let last = segments.last().copied().unwrap_or("");
     let first_w = first.chars().count();
     let last_w = last.chars().count();
-    // Stage 1: `{first}/…/{last}` — needs first + 3 (for `/…/`) + last chars.
-    let stage1_w = first_w + 3 + last_w;
-    if stage1_w <= max_width {
+    if first_w + 3 + last_w <= max_width {
         return format!("{first}/{ELLIPSIS}/{last}");
     }
-    // Stage 2: `…/{last}` — needs 2 + last chars.
-    let stage2_w = 2 + last_w;
-    if stage2_w <= max_width {
+    if 2 + last_w <= max_width {
         return format!("{ELLIPSIS}/{last}");
     }
-    // Stage 3: leaf alone is too long; truncate it.
     keep_tail(last, max_width)
 }
 

--- a/src/render/frames/ledger.rs
+++ b/src/render/frames/ledger.rs
@@ -220,7 +220,33 @@ fn fallback_to_sections(frame: &RenderFrame, config: &RenderConfig) -> Vec<Strin
 }
 
 fn top_frame(line1: &Line1Metrics, config: &RenderConfig, ctx: &LedgerCtx) -> String {
-    let head = shared::identity_headline(line1, config, ctx.p, " · ");
+    // `╭─ {head} {dashes}─╮` — fixed overhead 3 (`╭─ `) + 1 (sep) + 2 (`─╮`)
+    // = 6 cells. Reserve 1 dash for visual continuity → budget is `inner - 5`.
+    let budget = ctx.inner.saturating_sub(5);
+
+    // Stage B: pill drop.
+    let mut head = shared::identity_headline_bounded(line1, config, ctx.p, " · ", budget);
+
+    // Stage C: path compression, then branch compression. Both reuse the
+    // same segment-aware helper from activity::truncate.
+    if visible_width(&head) > budget {
+        let mut shrunk = line1.clone();
+        let path_budget = (budget / 3).max(12);
+        shrunk.project_path = truncate::compress_path_segments(&line1.project_path, path_budget);
+        head = shared::identity_headline_bounded(&shrunk, config, ctx.p, " · ", budget);
+
+        if visible_width(&head) > budget {
+            let branch_budget = (budget / 4).max(8);
+            shrunk.git_branch = truncate::compress_path_segments(&line1.git_branch, branch_budget);
+            head = shared::identity_headline_bounded(&shrunk, config, ctx.p, " · ", budget);
+        }
+    }
+
+    // Last resort: tail-ellipsis the entire (already ANSI-colored) headline.
+    if visible_width(&head) > budget {
+        head = layout::truncate_to_width(&head, budget, ctx.color);
+    }
+
     let head_w = visible_width(&head);
     let dashes_after = ctx.inner.saturating_sub(head_w + 4);
     let lhs = colorize(

--- a/src/render/frames/ledger.rs
+++ b/src/render/frames/ledger.rs
@@ -219,35 +219,52 @@ fn fallback_to_sections(frame: &RenderFrame, config: &RenderConfig) -> Vec<Strin
     layout::render_frame(frame, &shrunk)
 }
 
+/// `╭─ {head} {dashes}─╮` — fixed overhead = 3 (`╭─ `) + 1 (sep) + 2 (`─╮`)
+/// = 6 cells. Reserving 1 dash for visual continuity leaves headline
+/// budget = `ctx.inner - 5`.
+const HEADLINE_FRAME_OVERHEAD: usize = 5;
+
+/// Fraction of headline budget allocated to path / branch when stage C
+/// compression kicks in. Generous enough that a compressed `~/…/leaf`
+/// always fits, but tight enough to leave room for model + pills.
+/// Floors guarantee a useful leaf even at narrow terminals.
+const PATH_BUDGET_DIVISOR: usize = 3;
+const PATH_BUDGET_FLOOR: usize = 12;
+const BRANCH_BUDGET_DIVISOR: usize = 4;
+const BRANCH_BUDGET_FLOOR: usize = 8;
+
 fn top_frame(line1: &Line1Metrics, config: &RenderConfig, ctx: &LedgerCtx) -> String {
-    // `╭─ {head} {dashes}─╮` — fixed overhead 3 (`╭─ `) + 1 (sep) + 2 (`─╮`)
-    // = 6 cells. Reserve 1 dash for visual continuity → budget is `inner - 5`.
-    let budget = ctx.inner.saturating_sub(5);
+    let budget = ctx.inner.saturating_sub(HEADLINE_FRAME_OVERHEAD);
 
-    // Stage B: pill drop.
     let mut head = shared::identity_headline_bounded(line1, config, ctx.p, " · ", budget);
+    let mut head_w = visible_width(&head);
 
-    // Stage C: path compression, then branch compression. Both reuse the
-    // same segment-aware helper from activity::truncate.
-    if visible_width(&head) > budget {
-        let mut shrunk = line1.clone();
-        let path_budget = (budget / 3).max(12);
-        shrunk.project_path = truncate::compress_path_segments(&line1.project_path, path_budget);
-        head = shared::identity_headline_bounded(&shrunk, config, ctx.p, " · ", budget);
+    if head_w > budget {
+        let mut compressed = line1.clone();
+        let path_budget = (budget / PATH_BUDGET_DIVISOR).max(PATH_BUDGET_FLOOR);
+        compressed.project_path =
+            truncate::compress_path_segments(&line1.project_path, path_budget);
+        head = shared::identity_headline_bounded(&compressed, config, ctx.p, " · ", budget);
+        head_w = visible_width(&head);
 
-        if visible_width(&head) > budget {
-            let branch_budget = (budget / 4).max(8);
-            shrunk.git_branch = truncate::compress_path_segments(&line1.git_branch, branch_budget);
-            head = shared::identity_headline_bounded(&shrunk, config, ctx.p, " · ", budget);
+        // Branch compression stacks on top of the path compression above —
+        // do NOT reset `compressed` here.
+        if head_w > budget {
+            let branch_budget = (budget / BRANCH_BUDGET_DIVISOR).max(BRANCH_BUDGET_FLOOR);
+            compressed.git_branch =
+                truncate::compress_path_segments(&line1.git_branch, branch_budget);
+            head = shared::identity_headline_bounded(&compressed, config, ctx.p, " · ", budget);
+            head_w = visible_width(&head);
         }
     }
 
-    // Last resort: tail-ellipsis the entire (already ANSI-colored) headline.
-    if visible_width(&head) > budget {
+    // Safety net: tail-ellipsis the ANSI-colored headline when even
+    // both path AND branch compression couldn't bring it under budget.
+    if head_w > budget {
         head = layout::truncate_to_width(&head, budget, ctx.color);
+        head_w = visible_width(&head);
     }
 
-    let head_w = visible_width(&head);
     let dashes_after = ctx.inner.saturating_sub(head_w + 4);
     let lhs = colorize(
         &format!("{}{} ", ctx.g.tl, ctx.g.h),

--- a/src/render/frames/ledger.rs
+++ b/src/render/frames/ledger.rs
@@ -88,11 +88,15 @@ struct LedgerCtx<'a> {
 
 pub fn render(frame: &RenderFrame, config: &RenderConfig, p: &ThemePalette) -> Vec<String> {
     // Ledger needs a known terminal width — its rows are fixed-width
-    // framed. Fall back to console (content-sized) when width detection
-    // fails or the terminal is too narrow for the TAG-column rhythm.
-    let Some(width) = config.terminal_width.map(|w| w.min(config.pane_max_width)) else {
-        return fallback_to_sections(frame, config);
-    };
+    // framed. When detection fails (statusline hook context with no
+    // accessible /dev/tty), assume `pane_max_width` rather than falling
+    // back — falling back loses the user's chosen ledger layout for what
+    // is the common-case invocation context. Only when the terminal is
+    // *known* to be narrower than the TAG-column rhythm does Console win.
+    let width = config
+        .terminal_width
+        .map(|w| w.min(config.pane_max_width))
+        .unwrap_or(config.pane_max_width);
     if width < 90 {
         return fallback_to_sections(frame, config);
     }

--- a/src/render/frames/shared.rs
+++ b/src/render/frames/shared.rs
@@ -627,20 +627,19 @@ mod tests {
     }
 
     fn cfg_identity_all_on() -> RenderConfig {
-        let mut c = RenderConfig {
+        RenderConfig {
             color_enabled: false,
+            show_model: true,
+            show_version: true,
+            show_effort: true,
+            show_thinking: true,
+            show_agent: true,
+            show_project: true,
+            show_git: true,
+            show_git_stats: true,
+            show_worktree: true,
             ..RenderConfig::default()
-        };
-        c.show_model = true;
-        c.show_version = true;
-        c.show_effort = true;
-        c.show_thinking = true;
-        c.show_agent = true;
-        c.show_project = true;
-        c.show_git = true;
-        c.show_git_stats = true;
-        c.show_worktree = true;
-        c
+        }
     }
 
     #[test]

--- a/src/render/frames/shared.rs
+++ b/src/render/frames/shared.rs
@@ -285,6 +285,51 @@ pub fn identity_headline(
     parts.join(&coloured_sep)
 }
 
+/// Width-aware identity headline. When the full headline fits in
+/// `max_width` (visible chars), returns `identity_headline` unchanged.
+/// Otherwise drops optional pills in low-signal-first order until the
+/// result fits, returning the final attempt regardless.
+///
+/// **Never auto-drops** `show_model`, `show_project`, `show_git` —
+/// those define identity. Callers are expected to handle further
+/// overflow via path/branch compression and/or tail-ellipsis.
+///
+/// Mirrors `config_row`'s clone-mutate-remeasure pattern: clones
+/// `RenderConfig` once, mutates the clone per DROP_ORDER step, never
+/// clones `Line1Metrics`.
+pub fn identity_headline_bounded(
+    line1: &Line1Metrics,
+    config: &RenderConfig,
+    p: &ThemePalette,
+    separator: &str,
+    max_width: usize,
+) -> String {
+    let head = identity_headline(line1, config, p, separator);
+    if visible_width(&head) <= max_width {
+        return head;
+    }
+
+    const DROP_ORDER: &[fn(&mut RenderConfig)] = &[
+        |c| c.show_version = false,
+        |c| c.show_git_stats = false,
+        |c| c.show_worktree = false,
+        |c| c.show_effort = false,
+        |c| c.show_agent = false,
+        |c| c.show_thinking = false,
+    ];
+
+    let mut shrunk = config.clone();
+    let mut last = head;
+    for drop in DROP_ORDER {
+        drop(&mut shrunk);
+        last = identity_headline(line1, &shrunk, p, separator);
+        if visible_width(&last) <= max_width {
+            return last;
+        }
+    }
+    last
+}
+
 /// Compact L2 config row, width-aware. Delegates to `format_line2` in
 /// `layout.rs` so the icons, counts, and toggles stay in lockstep across
 /// layouts. When the assembled row exceeds `max_width`, segments are
@@ -561,5 +606,122 @@ mod tests {
     fn config_row_enabled_false_when_everything_off() {
         // Sanity guard for the predicate's negative case.
         assert!(!config_row_enabled(&cfg_all_off()));
+    }
+
+    fn line1_with_all_optional_pills() -> Line1Metrics {
+        Line1Metrics {
+            model: "Opus 4.7".to_string(),
+            claude_code_version: "2.1.138".to_string(),
+            project_path: "~/repo".to_string(),
+            git_branch: "main".to_string(),
+            git_dirty: true,
+            git_modified: 3,
+            git_added: 2,
+            git_untracked: 1,
+            agent_name: Some("greg-bot".to_string()),
+            in_worktree: true,
+            effort_level: Some("high".to_string()),
+            thinking_enabled: Some(true),
+            ..Line1Metrics::default()
+        }
+    }
+
+    fn cfg_identity_all_on() -> RenderConfig {
+        let mut c = RenderConfig {
+            color_enabled: false,
+            ..RenderConfig::default()
+        };
+        c.show_model = true;
+        c.show_version = true;
+        c.show_effort = true;
+        c.show_thinking = true;
+        c.show_agent = true;
+        c.show_project = true;
+        c.show_git = true;
+        c.show_git_stats = true;
+        c.show_worktree = true;
+        c
+    }
+
+    #[test]
+    fn bounded_returns_unchanged_when_fits() {
+        let line1 = line1_with_all_optional_pills();
+        let cfg = cfg_identity_all_on();
+        let palette = ThemePalette::default();
+        let full = identity_headline(&line1, &cfg, &palette, " · ");
+        let bounded = identity_headline_bounded(&line1, &cfg, &palette, " · ", 1000);
+        assert_eq!(bounded, full);
+    }
+
+    #[test]
+    fn bounded_drops_version_first() {
+        let line1 = line1_with_all_optional_pills();
+        let cfg = cfg_identity_all_on();
+        let palette = ThemePalette::default();
+        let full = identity_headline(&line1, &cfg, &palette, " · ");
+        // Budget just below full → exactly one drop should occur (version).
+        let budget = visible_width(&full) - 1;
+        let bounded = identity_headline_bounded(&line1, &cfg, &palette, " · ", budget);
+        assert!(
+            !bounded.contains("CC:"),
+            "show_version should drop first; got {bounded:?}"
+        );
+        // Other optional pills survive.
+        assert!(bounded.contains("Opus 4.7"));
+        assert!(bounded.contains("high"));
+        assert!(bounded.contains("greg-bot"));
+    }
+
+    #[test]
+    fn bounded_drops_thinking_last_among_optionals() {
+        let line1 = line1_with_all_optional_pills();
+        let cfg = cfg_identity_all_on();
+        let palette = ThemePalette::default();
+        // Tight budget that forces every optional pill to drop. After all
+        // DROP_ORDER iterations the result must NOT include the thinking
+        // pill (it's last in DROP_ORDER, dropped last).
+        let bounded = identity_headline_bounded(&line1, &cfg, &palette, " · ", 20);
+        assert!(
+            !bounded.contains("[T]"),
+            "thinking should drop after all others; got {bounded:?}"
+        );
+    }
+
+    #[test]
+    fn bounded_never_drops_model_or_project_or_git() {
+        let line1 = line1_with_all_optional_pills();
+        let cfg = cfg_identity_all_on();
+        let palette = ThemePalette::default();
+        // Impossibly tight budget — even after all DROP_ORDER fires,
+        // model/project/git are still present (no auto-drop for these).
+        let bounded = identity_headline_bounded(&line1, &cfg, &palette, " · ", 1);
+        assert!(bounded.contains("Opus 4.7"));
+        assert!(bounded.contains("~/repo"));
+        assert!(bounded.contains("main"));
+    }
+
+    #[test]
+    fn bounded_drops_git_stats_without_dropping_branch() {
+        let line1 = line1_with_all_optional_pills();
+        let cfg = cfg_identity_all_on();
+        let palette = ThemePalette::default();
+        // Pin budget to "version off, but everything else on" minus 1, so the
+        // bounded loop is forced to drop the NEXT item after version. Per
+        // DROP_ORDER that's git_stats. Branch + dirty marker must survive.
+        let mut cfg_no_version = cfg.clone();
+        cfg_no_version.show_version = false;
+        let no_version_w =
+            visible_width(&identity_headline(&line1, &cfg_no_version, &palette, " · "));
+        let budget = no_version_w - 1;
+        let bounded = identity_headline_bounded(&line1, &cfg, &palette, " · ", budget);
+        assert!(bounded.contains("main"), "branch survived; got {bounded:?}");
+        assert!(
+            bounded.contains('*'),
+            "dirty marker survives; got {bounded:?}"
+        );
+        assert!(
+            !bounded.contains("!3"),
+            "git_stats dropped; got {bounded:?}"
+        );
     }
 }

--- a/src/render/layout.rs
+++ b/src/render/layout.rs
@@ -699,7 +699,7 @@ fn lines_fit_width(lines: &[String], width: usize) -> bool {
     lines.iter().all(|line| visible_width(line) <= width)
 }
 
-fn truncate_to_width(line: &str, width: usize, color_enabled: bool) -> String {
+pub fn truncate_to_width(line: &str, width: usize, color_enabled: bool) -> String {
     if visible_width(line) <= width {
         return line.to_string();
     }

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -73,7 +73,7 @@ fn version_flag_shows_version() {
         stdout.contains("cc-pulseline"),
         "should contain binary name"
     );
-    assert!(stdout.contains("1.1.2"), "should contain version number");
+    assert!(stdout.contains("1.1.3"), "should contain version number");
 }
 
 #[test]
@@ -86,7 +86,7 @@ fn short_version_flag_works() {
     assert!(output.status.success(), "should exit 0");
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(
-        stdout.contains("cc-pulseline 1.1.2"),
+        stdout.contains("cc-pulseline 1.1.3"),
         "should show name and version"
     );
 }

--- a/tests/ledger_layout.rs
+++ b/tests/ledger_layout.rs
@@ -378,6 +378,73 @@ fn ledger_sparkline_window_respects_1min_floor() {
     assert!(ctx_row.contains("→"), "delta arrow: {ctx_row:?}");
 }
 
+// ─────────────────────────────────────────────────────────────────────
+// Frame width invariants — top border must always equal bottom border
+// across realistic long-path / long-branch combos. Catches the bug where
+// `top_frame` left `head` un-truncated when it exceeded `ctx.inner`,
+// pushing the right `╮` past the terminal width.
+// ─────────────────────────────────────────────────────────────────────
+
+fn make_frame(path: &str, branch: &str) -> RenderFrame {
+    let mut f = frame_basic();
+    f.line1.project_path = path.to_string();
+    f.line1.git_branch = branch.to_string();
+    f
+}
+
+#[test]
+fn ledger_top_border_width_matches_bottom_across_widths() {
+    use cc_pulseline::render::color::visible_width;
+
+    let short_path = "~/cc-pulseline";
+    let short_branch = "main";
+    let long_path = "~/Workspace/Paradise/Frontend/platform-1.0/platform-web";
+    let long_branch = "feature/e2e-traceability-rollout-integration";
+
+    let cases: &[(&str, &str, &str)] = &[
+        ("short_path_short_branch", short_path, short_branch),
+        ("long_path_short_branch", long_path, short_branch),
+        ("short_path_long_branch", short_path, long_branch),
+        ("long_path_long_branch", long_path, long_branch),
+    ];
+    let widths = [100usize, 140, 200, 240];
+
+    for w in widths {
+        for (label, path, branch) in cases {
+            let f = make_frame(path, branch);
+            let lines = render_frame(&f, &cfg(w));
+            let top = lines.first().expect("top frame line");
+            let bottom = lines.last().expect("bottom frame line");
+            assert_eq!(
+                visible_width(top),
+                visible_width(bottom),
+                "width {w}, case {label}\n  top:    {top}\n  bottom: {bottom}",
+            );
+        }
+    }
+}
+
+#[test]
+fn ledger_top_aligns_under_long_path_and_branch_at_100_cols() {
+    use cc_pulseline::render::color::visible_width;
+
+    // Direct repro of the user-reported screenshot conditions.
+    let f = make_frame(
+        "~/Workspace/Paradise/Frontend/platform-1.0/platform-web",
+        "feature/e2e-traceability-rollout-integration",
+    );
+    let lines = render_frame(&f, &cfg(100));
+    let top = lines.first().expect("top frame line");
+    let bottom = lines.last().expect("bottom frame line");
+    assert_eq!(
+        visible_width(top),
+        visible_width(bottom),
+        "headline must self-bound\n  top:    {top}\n  bottom: {bottom}",
+    );
+    // Right edge `╮` must appear — its absence is the original bug signal.
+    assert!(top.contains('╮'), "top frame has right corner: {top}");
+}
+
 #[test]
 fn ledger_all_complete_celebration_line() {
     use cc_pulseline::types::TodoSummary;

--- a/tests/ledger_layout.rs
+++ b/tests/ledger_layout.rs
@@ -446,6 +446,31 @@ fn ledger_top_aligns_under_long_path_and_branch_at_100_cols() {
 }
 
 #[test]
+fn ledger_renders_at_pane_max_width_when_terminal_width_unknown() {
+    // Reproduces the statusline-hook context where `/dev/tty` is
+    // unreachable and `COLUMNS` is unset or `"0"` → `terminal_width: None`.
+    // Pre-fix: ledger fell back to Console (sections), surfacing internal
+    // `├─┼─┤` row separators and a `│ TAG │ body │` cell border, which
+    // doesn't match the user's chosen ledger layout.
+    let mut c = cfg(140);
+    c.terminal_width = None;
+    let f = frame_basic();
+    let lines = render_frame(&f, &c);
+    let blob = lines.join("\n");
+
+    assert!(
+        !blob.contains('├') && !blob.contains('┼') && !blob.contains('┤'),
+        "ledger should not render Console sections separators (├ ┼ ┤) when width is unknown\n{blob}"
+    );
+    let top = lines.first().expect("top frame line");
+    assert!(
+        top.starts_with('╭'),
+        "top frame line must start with ╭: {top}"
+    );
+    assert!(top.contains('╮'), "top frame line must end with ╮: {top}");
+}
+
+#[test]
 fn ledger_all_complete_celebration_line() {
     use cc_pulseline::types::TodoSummary;
     let mut f = frame_basic();

--- a/tests/ledger_layout.rs
+++ b/tests/ledger_layout.rs
@@ -471,6 +471,44 @@ fn ledger_renders_at_pane_max_width_when_terminal_width_unknown() {
 }
 
 #[test]
+fn ledger_unknown_width_honors_pane_max_width_and_aligns_borders() {
+    use cc_pulseline::render::color::visible_width;
+
+    // Pin two invariants for the `terminal_width: None` code path:
+    //   (1) top width == bottom width (frame geometry)
+    //   (2) frame width tracks `pane_max_width` (width sourcing — proves
+    //       we didn't accidentally regress to a hardcoded default or to
+    //       ignoring the user's max_width override).
+    // The exact delta between `pane_max_width` and the rendered frame
+    // width is governed by FRAME_INNER_PAD (private to ledger.rs); we
+    // assert a loose bound rather than the exact number so the test
+    // survives constant tuning.
+    let f = frame_basic();
+    for max_w in [100usize, 120, 140, 180] {
+        let mut c = cfg(140);
+        c.terminal_width = None;
+        c.pane_max_width = max_w;
+        let lines = render_frame(&f, &c);
+        let top = lines.first().expect("top frame line");
+        let bottom = lines.last().expect("bottom frame line");
+        let top_w = visible_width(top);
+        let bot_w = visible_width(bottom);
+
+        assert_eq!(
+            top_w, bot_w,
+            "borders must align at pane_max_width={max_w}\n  top: {top}\n  bot: {bottom}"
+        );
+        // Loose: frame width is within 10 cells of pane_max_width (private
+        // FRAME_INNER_PAD = 5 currently yields top_w == pane_max_width - 3).
+        let lower = max_w.saturating_sub(10);
+        assert!(
+            (lower..=max_w).contains(&top_w),
+            "frame width {top_w} should track pane_max_width={max_w} (within 10)\n  top: {top}"
+        );
+    }
+}
+
+#[test]
 fn ledger_all_complete_celebration_line() {
     use cc_pulseline::types::TodoSummary;
     let mut f = frame_basic();


### PR DESCRIPTION
## Summary

Two related ledger-rendering issues, both exposed by the v1.1.2 \`CC:\` pill addition.

### 1. Top-frame border misalignment (original report)

- **Root cause**: \`top_frame\` used \`saturating_sub\` to compute trailing dashes, which prevents numeric underflow but does **not** truncate the headline itself. With long path/branch + the new \`CC:\` pill, headlines exceeded the inner frame width, pushing the right corner \`╮\` past the body.
- **Fix** (3-stage cascade in \`top_frame\`): (B) drop optional identity pills via \`identity_headline_bounded\` (DROP_ORDER: \`version → git_stats → worktree → effort → agent → thinking\`); (C) compress \`project_path\` with segment-aware ellipsis (\`{first}/…/{last}\` → \`…/{last}\` → \`keep_tail\`); then same compression for \`git_branch\`; safety net: \`truncate_to_width\` tail-ellipsis.
- New helpers are pure additions — \`compress_path_segments\` clusters with existing \`keep_tail\`/\`keep_middle\`; \`identity_headline_bounded\` mirrors the \`config_row\` clone-mutate-remeasure pattern.

### 2. Width detection silently downgrading ledger → Console (follow-up)

Discovered during PR review: the live statusline hook context (bg session, no \`/dev/tty\`, \`COLUMNS=0\` inherited from parent) was making \`detect_terminal_width()\` return \`Some(0)\`. Ledger then took the \`< 90\` fallback path and rendered as Console sections (\`├─┼─┤\` separators), losing the user's chosen layout.

- **\`resolve_terminal_width\`**: reject \`COLUMNS=\"0\"\` and \`ioctl=Some(0)\`, fall through cleanly so the function returns \`None\` when no usable width exists.
- **Ledger render**: when \`terminal_width\` is unknown, assume \`pane_max_width\` (default 140) instead of falling back. The hook context is the common case; only an *observed* width below 90 still triggers Console fallback.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` zero warnings
- [x] \`cargo test\` — all suites pass
- [x] **Headline overflow**: \`ledger_top_border_width_matches_bottom_across_widths\` invariant across \`[100, 140, 160, 200]\` × 4 path/branch combinations
- [x] **Direct repro**: \`ledger_top_aligns_under_long_path_and_branch_at_100_cols\`
- [x] **Width=0 rejection**: 3 new \`resolve_terminal_width\` cases (\`COLUMNS=\"0\"\` + ioctl, \`COLUMNS=\"0\"\` alone, \`ioctl=Some(0)\`)
- [x] **Ledger-not-Console**: \`ledger_renders_at_pane_max_width_when_terminal_width_unknown\` asserts no \`├ ┼ ┤\` leak when \`terminal_width: None\`