### PR TITLE
Release 1.1.4: preserve CC: pill when path is long (cascade reorder)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "pulseline",
       "description": "Setup and manage the cc-pulseline statusline — install binary, configure display, and diagnose issues",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "source": ".",
       "category": "productivity"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pulseline",
   "description": "High-performance multi-line statusline for Claude Code with setup commands and diagnostics",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "author": {
     "name": "cc-pulseline"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.4] - 2026-05-13
+
+Patch release fixing a regression introduced by v1.1.3's ledger headline
+overflow cascade: the `CC:` version pill (and other optional pills) was
+being dropped before `project_path` / `git_branch` were compressed, so a
+long project path could hide `CC:` even when the user had `show_version =
+true`. The cascade is now inverted — data is compressed first, pills drop
+only as the last resort before tail-ellipsis truncation.
+
+### Fixed
+
+- **Ledger headline dropping `CC:` version pill (and other optional
+  pills) before compressing long path/branch** — `top_frame`'s overflow
+  cascade was ordered `bounded(drops pills) → compress path → compress
+  branch → tail`. With a long `project_path` (e.g. 57+ chars) the
+  `identity_headline_bounded` call at stage 1 already dropped `version`
+  via `DROP_ORDER`, so subsequent compression stages saw a pill-less
+  headline and the user lost `CC:` even at wide terminals. The cascade
+  is now reordered to `full → compress path → compress branch → bounded
+  (drops pills) → tail`: pill drop only fires after both data
+  compressions failed to fit.
+
+### Internal
+
+- Regression test `ledger_preserves_show_version_when_path_is_long`
+  (`tests/ledger_layout.rs`) — Pins the new behavior using the
+  platform-web case (57-char path, 33-char branch) across widths 120
+  through 240; asserts `top.contains("2.1.138")` (the CC: pill version
+  string) at every width.
+
 ## [1.1.3] - 2026-05-12
 
 Patch release fixing two ledger-rendering bugs exposed by the v1.1.2 `CC:`
@@ -407,6 +437,7 @@ collision on L1 is fixed in every built-in theme.
 - **Context alert thresholds** at 70%/55% — warnings appear before Claude Code's ~80% auto-compact triggers
 - **Steel blue completed checkmarks** — distinct from plan-mode green to avoid visual collision
 
+[1.1.4]: https://github.com/GregoryHo/cc-pulseline/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/GregoryHo/cc-pulseline/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/GregoryHo/cc-pulseline/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/GregoryHo/cc-pulseline/compare/v1.1.0...v1.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc-pulseline"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "criterion",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc-pulseline"
-version = "1.1.3"
+version = "1.1.4"
 edition = "2021"
 rust-version = "1.85"
 description = "High-performance multi-line statusline for Claude Code with deep observability"

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Recognized widgets: `gauge`, `sparkline`, `text` for context; `gauge`, `text` fo
 ## CLI Usage
 
 ```
-cc-pulseline 1.1.3 - High-performance Claude Code statusline
+cc-pulseline 1.1.4 - High-performance Claude Code statusline
 
 USAGE:
     cc-pulseline [OPTIONS]

--- a/src/render/frames/ledger.rs
+++ b/src/render/frames/ledger.rs
@@ -240,30 +240,43 @@ const BRANCH_BUDGET_FLOOR: usize = 8;
 fn top_frame(line1: &Line1Metrics, config: &RenderConfig, ctx: &LedgerCtx) -> String {
     let budget = ctx.inner.saturating_sub(HEADLINE_FRAME_OVERHEAD);
 
-    let mut head = shared::identity_headline_bounded(line1, config, ctx.p, " · ", budget);
+    // Cascade prefers data compression (ellipsis on path/branch — visibly
+    // recoverable) before pill drop (toggle off — entire segment vanishes).
+    // A user who explicitly enabled `show_version` shouldn't lose the CC:
+    // pill just because their project path is long; long paths should turn
+    // into `~/…/leaf` first.
+
+    // Stage 1: full headline, no compression, no pill drop.
+    let mut head = shared::identity_headline(line1, config, ctx.p, " · ");
     let mut head_w = visible_width(&head);
 
     if head_w > budget {
+        // Stage 2: compress project_path.
         let mut compressed = line1.clone();
         let path_budget = (budget / PATH_BUDGET_DIVISOR).max(PATH_BUDGET_FLOOR);
         compressed.project_path =
             truncate::compress_path_segments(&line1.project_path, path_budget);
-        head = shared::identity_headline_bounded(&compressed, config, ctx.p, " · ", budget);
+        head = shared::identity_headline(&compressed, config, ctx.p, " · ");
         head_w = visible_width(&head);
 
-        // Branch compression stacks on top of the path compression above —
-        // do NOT reset `compressed` here.
         if head_w > budget {
+            // Stage 3: compress git_branch (stacks on the path compression).
             let branch_budget = (budget / BRANCH_BUDGET_DIVISOR).max(BRANCH_BUDGET_FLOOR);
             compressed.git_branch =
                 truncate::compress_path_segments(&line1.git_branch, branch_budget);
-            head = shared::identity_headline_bounded(&compressed, config, ctx.p, " · ", budget);
+            head = shared::identity_headline(&compressed, config, ctx.p, " · ");
             head_w = visible_width(&head);
+
+            if head_w > budget {
+                // Stage 4: drop pills via DROP_ORDER on the already-compressed line1.
+                head = shared::identity_headline_bounded(&compressed, config, ctx.p, " · ", budget);
+                head_w = visible_width(&head);
+            }
         }
     }
 
-    // Safety net: tail-ellipsis the ANSI-colored headline when even
-    // both path AND branch compression couldn't bring it under budget.
+    // Safety net: tail-ellipsis the ANSI-colored headline when even pill
+    // drop on top of full data compression couldn't bring it under budget.
     if head_w > budget {
         head = layout::truncate_to_width(&head, budget, ctx.color);
         head_w = visible_width(&head);

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -73,7 +73,7 @@ fn version_flag_shows_version() {
         stdout.contains("cc-pulseline"),
         "should contain binary name"
     );
-    assert!(stdout.contains("1.1.3"), "should contain version number");
+    assert!(stdout.contains("1.1.4"), "should contain version number");
 }
 
 #[test]
@@ -86,7 +86,7 @@ fn short_version_flag_works() {
     assert!(output.status.success(), "should exit 0");
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(
-        stdout.contains("cc-pulseline 1.1.3"),
+        stdout.contains("cc-pulseline 1.1.4"),
         "should show name and version"
     );
 }

--- a/tests/ledger_layout.rs
+++ b/tests/ledger_layout.rs
@@ -446,6 +446,35 @@ fn ledger_top_aligns_under_long_path_and_branch_at_100_cols() {
 }
 
 #[test]
+fn ledger_preserves_show_version_when_path_is_long() {
+    // Regression test for v1.1.3 → v1.1.4 cascade reorder: a user who
+    // explicitly enables `show_version = true` should not lose the CC:
+    // pill just because their project path is long. The cascade must
+    // compress path/branch (visibly recoverable as `~/…/leaf`) before
+    // dropping any pill (toggle off — entire segment vanishes).
+    //
+    // Repro case: platform-web — path 57 chars, branch 40 chars,
+    // `show_version` + `show_git_stats` both on. At pane_max_width=140
+    // the full headline overflows by ~20 chars. Pre-fix DROP_ORDER
+    // killed the CC: pill first; post-fix the path compresses to
+    // `~/…/platform-web` and the pill survives.
+    let mut f = make_frame(
+        "~/Workspace/Paradise/Frontend/platform-1.0/platform-web",
+        "feature/e2e-traceability-graph-viz",
+    );
+    f.line1.claude_code_version = "2.1.138".to_string();
+
+    for w in [120usize, 140, 160, 200, 240] {
+        let lines = render_frame(&f, &cfg(w));
+        let top = lines.first().expect("top frame line");
+        assert!(
+            top.contains("2.1.138"),
+            "CC: pill must survive path overflow at width={w}\n  top: {top}"
+        );
+    }
+}
+
+#[test]
 fn ledger_renders_at_pane_max_width_when_terminal_width_unknown() {
     // Reproduces the statusline-hook context where `/dev/tty` is
     // unreachable and `COLUMNS` is unset or `"0"` → `terminal_width: None`.


### PR DESCRIPTION
## Summary

Reorders the ledger top-frame headline overflow cascade. Previously dropped pills (e.g. CC: version) before compressing path/branch — meaning users who explicitly enabled `show_version = true` lost the CC: pill in any project with a long path (e.g. platform-web's 57-char path + 40-char branch), even at wide terminal widths.

**New cascade order in `top_frame`:**
1. Build full headline (no compression, no drop).
2. If overflow: compress `project_path` (`{first}/…/{last}`).
3. If overflow: compress `git_branch` (stacks on path compression).
4. If overflow: drop pills via `identity_headline_bounded` (DROP_ORDER unchanged).
5. Safety net: tail-ellipsis the colored output.

**Principle**: data compression (visibly recoverable as `…`) takes precedence over toggle drop (segment vanishes entirely). User intent — "I enabled this pill, I want to see it" — is now respected unless even full data compression can't bring the headline under budget.

## Trade-off

Long-path projects will see `~/…/leaf` ellipsis on the path more often. The previous behavior preserved full path strings at the cost of dropping pills; the new behavior preserves pills at the cost of path ellipsis.

## Repro case (platform-web)

| Width | v1.1.3 (before) | v1.1.4 (after) |
|---|---|---|
| 240 | `╭─ Opus 4.7 · ~/Workspace/Paradise/Frontend/platform-1.0/platform-web · feature/...` (no CC:) | `╭─  2.1.138 · Opus 4.7 · ~/…/platform-web · feature/...` (CC: present) |
| 140 | (CC: dropped) | (CC: present + path compressed) |

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` zero warnings
- [x] `cargo test` — all 25 suites pass
- [x] New regression test `ledger_preserves_show_version_when_path_is_long` pins CC: pill at widths `[120, 140, 160, 200, 240]` for platform-web repro
- [x] All existing ledger_layout tests still pass (border alignment, fallback paths, width-detection, etc.)
- [x] Manual smoke at platform-web payload: CC: pill present at every tested width

## Release plan

This will ship as **v1.1.4** patch on top of v1.1.3 (which introduced the original cascade in `top_frame`). Release-bump commits not in this PR yet — will follow separately after review.