### PR TITLE
Release 1.1.5: sub-agent TODO tailing + ledger lazy separators

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "pulseline",
       "description": "Setup and manage the cc-pulseline statusline — install binary, configure display, and diagnose issues",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "source": ".",
       "category": "productivity"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pulseline",
   "description": "High-performance multi-line statusline for Claude Code with setup commands and diagnostics",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "author": {
     "name": "cc-pulseline"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.5] - 2026-05-19
+
+Feature release on two axes: sub-agent TODO visibility from dispatched
+agent transcripts, and a ledger spacing fix that eliminates trailing
+blank rows above the bottom frame plus a new `ledger_dense` toggle.
+
+### Added
+
+- **Sub-agent TODO tailing** — When the active session dispatches one or
+  more sub-agents (via the `Agent` tool), the TODO row now surfaces
+  in-progress state from the sub-agent's own transcript rather than
+  silently reporting the lead agent's empty list. Counts in TOOL /
+  AGENT / TODO rows aggregate across the lead session and active
+  sub-agents so the statusline reflects the whole tree of work.
+- **`[layout] ledger_dense`** (default `false`) — compact rhythm for
+  the `ledger` layout that drops every inter-group blank row. Useful
+  when statusline vertical room is tight. Group separators in legacy
+  mode (`false`) are now inserted *lazily*, so no trailing blank can
+  reach the bottom frame regardless of which groups are populated.
+
+### Fixed
+
+- **Stray trailing blank above ledger `bottom_frame` when TOOL was the
+  last non-empty group** — the inter-group blank after TOOL was pushed
+  unconditionally whenever any tool rows rendered, even when AGENT /
+  TODO were empty. The render pipeline now builds groups first and
+  inserts separators lazily, so the bottom frame closes flush against
+  the last content row regardless of which groups are present.
+
+### Internal
+
+- Ledger `render()` refactored to a `Vec<Vec<String>>` group pipeline
+  with a single lazy-separator flatten loop, replacing three hardcoded
+  `blank_row()` push points in `src/render/frames/ledger.rs`.
+- 3 new ledger spacing tests:
+  `ledger_no_trailing_blank_when_tools_last`,
+  `ledger_dense_drops_all_inter_group_blanks`,
+  `ledger_dense_false_preserves_legacy_spacing`
+  (`tests/ledger_layout.rs`).
+- New transcript dispatcher for sub-agent events with state-merge
+  helpers in `src/state/mod.rs` and `src/providers/transcript.rs`;
+  covered by `tests/sub_agent_transcripts.rs` and an updated
+  `tests/adaptive_performance.rs`.
+
 ## [1.1.4] - 2026-05-13
 
 Patch release fixing a regression introduced by v1.1.3's ledger headline
@@ -437,6 +481,7 @@ collision on L1 is fixed in every built-in theme.
 - **Context alert thresholds** at 70%/55% — warnings appear before Claude Code's ~80% auto-compact triggers
 - **Steel blue completed checkmarks** — distinct from plan-mode green to avoid visual collision
 
+[1.1.5]: https://github.com/GregoryHo/cc-pulseline/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/GregoryHo/cc-pulseline/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/GregoryHo/cc-pulseline/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/GregoryHo/cc-pulseline/compare/v1.1.1...v1.1.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc-pulseline"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "criterion",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc-pulseline"
-version = "1.1.4"
+version = "1.1.5"
 edition = "2021"
 rust-version = "1.85"
 description = "High-performance multi-line statusline for Claude Code with deep observability"

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Recognized widgets: `gauge`, `sparkline`, `text` for context; `gauge`, `text` fo
 ## CLI Usage
 
 ```
-cc-pulseline 1.1.4 - High-performance Claude Code statusline
+cc-pulseline 1.1.5 - High-performance Claude Code statusline
 
 USAGE:
     cc-pulseline [OPTIONS]

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -200,7 +200,6 @@ rows separate logical groups. Tallest layout.
 │                                                                         │
 │  AGENT   󱦻 Explore   Investigate parser edge case   [haiku]   <1s       │
 │  TODO    0/3 done · 3 pending                                           │
-│                                                                         │
 ╰─────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -223,6 +222,31 @@ delta label remains).
 **Pick when** the statusline pane has plenty of vertical room and you
 want to scan metrics by group rather than density. Below 90 cols falls
 back to `sections`.
+
+#### Spacing: `ledger_dense`
+
+Group separators in ledger are inserted *lazily* — a blank row only
+appears between two non-empty groups. Trailing blanks above the bottom
+frame are not possible regardless of which groups are populated.
+
+`[layout] ledger_dense = true` drops every inter-group blank for a
+compact rhythm, useful when statusline vertical room is tight:
+
+```
+╭─ … ──────────────────────────────────╮
+│  ENV     ...                          │
+│  CTX     ...                          │
+│  TOK     ...                          │
+│  COST    ...                          │
+│  5h      ...                          │
+│  TOOL    ...                          │
+│  AGENT   ...                          │
+│  TODO    ...                          │
+╰───────────────────────────────────────╯
+```
+
+Default is `false` (legacy rhythm: one blank between ENV, Budget+Quota,
+TOOL, and AGENT+TODO groups).
 
 ---
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,9 @@ fn default_layout_cc_margin() -> usize {
 fn default_layout_tonal_strata() -> bool {
     true
 }
+fn default_layout_ledger_dense() -> bool {
+    false
+}
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct LayoutSection {
@@ -73,6 +76,9 @@ pub struct LayoutSection {
     /// use `strata_activity`. See `designs/tonal-strata-redesign.md`.
     #[serde(default = "default_layout_tonal_strata")]
     pub tonal_strata: bool,
+    /// Ledger-only: drop all inter-group blank rows for a compact rhythm.
+    #[serde(default = "default_layout_ledger_dense")]
+    pub ledger_dense: bool,
 }
 
 impl Default for LayoutSection {
@@ -85,6 +91,7 @@ impl Default for LayoutSection {
             max_width: default_layout_max_width(),
             cc_margin: default_layout_cc_margin(),
             tonal_strata: default_layout_tonal_strata(),
+            ledger_dense: default_layout_ledger_dense(),
         }
     }
 }
@@ -545,6 +552,11 @@ max_width = 160         # clamp auto-sized frames to this many cols
 # `strata_state`, activity rows (Tools/Agents/Todos) get `strata_activity`.
 # Set to false for a fully flat baseline.
 tonal_strata = true
+
+# Ledger only: drop the blank rows that separate groups (ENV / Budget+Quota
+# / TOOL / AGENT+TODO). The bottom frame always closes flush against the
+# last content row regardless of this setting.
+ledger_dense = false
 "#
 }
 
@@ -567,6 +579,7 @@ pub struct ProjectLayoutOverride {
     pub max_width: Option<usize>,
     pub cc_margin: Option<usize>,
     pub tonal_strata: Option<bool>,
+    pub ledger_dense: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -887,6 +900,9 @@ pub fn merge_configs(
         if let Some(v) = layout.tonal_strata {
             user.layout.tonal_strata = v;
         }
+        if let Some(v) = layout.ledger_dense {
+            user.layout.ledger_dense = v;
+        }
     }
 
     user
@@ -1045,6 +1061,7 @@ pub fn default_project_config_toml() -> &'static str {
 # max_width = 140
 # cc_margin = 4             # "terminal" mode: cols subtracted for CC's slot padding
 # tonal_strata = true       # 2-tier separator tint: state rows vs activity rows
+# ledger_dense = false      # ledger-only: drop inter-group blank rows
 "#
 }
 
@@ -1139,6 +1156,8 @@ pub struct RenderConfig {
     pub pane_max_width: usize,
     pub pane_cc_margin: usize,
     pub pane_tonal_strata: bool,
+    /// Ledger-only: drop all inter-group blank rows for a compact rhythm.
+    pub pane_ledger_dense: bool,
 }
 
 impl RenderConfig {
@@ -1235,6 +1254,7 @@ impl Default for RenderConfig {
             pane_max_width: 140,
             pane_cc_margin: crate::render::pane::DEFAULT_PANE_CC_MARGIN,
             pane_tonal_strata: true,
+            pane_ledger_dense: false,
         }
     }
 }
@@ -1419,6 +1439,7 @@ pub fn build_render_config(pulseline: &PulselineConfig) -> RenderConfig {
         pane_max_width: pulseline.layout.max_width,
         pane_cc_margin: pulseline.layout.cc_margin,
         pane_tonal_strata: pulseline.layout.tonal_strata,
+        pane_ledger_dense: pulseline.layout.ledger_dense,
         ..RenderConfig::default()
     }
 }

--- a/src/providers/transcript.rs
+++ b/src/providers/transcript.rs
@@ -1,7 +1,7 @@
 use std::{
     fs::File,
     io::{Read, Seek, SeekFrom},
-    path::Path,
+    path::{Path, PathBuf},
     time::{Duration, Instant},
 };
 
@@ -87,7 +87,7 @@ use serde_json::Value;
 
 use crate::{
     config::RenderConfig,
-    state::SessionState,
+    state::{SessionState, SubAgentTranscriptState},
     types::{AgentSummary, CompletedToolCount, StdinPayload, TodoSummary, ToolSummary},
 };
 
@@ -173,6 +173,10 @@ impl TranscriptCollector for FileTranscriptCollector {
         state.last_transcript_offset = file_len;
         state.last_transcript_poll = Some(Instant::now());
 
+        // After the parent transcript is up-to-date, tail any sub-agent
+        // transcripts whose `agentId` the parent has already surfaced.
+        tail_sub_agent_transcripts(state, transcript_path, config);
+
         snapshot_from_state(state, config)
     }
 }
@@ -223,6 +227,32 @@ fn read_new_lines(path: &Path, start_offset: u64) -> Result<Vec<String>, String>
         .collect())
 }
 
+/// CC's async-agent dispatch marker emitted on the parent's tool_result
+/// `toolUseResult` envelope. The dispatched agent is still alive — this
+/// is a binding event (agentId is now known), not a completion.
+const STATUS_ASYNC_LAUNCHED: &str = "async_launched";
+
+/// Borrowed view of CC's `toolUseResult` async-agent envelope. Parses
+/// either the dispatch event (`status: "async_launched"`) or a terminal
+/// event (`status` matches `is_terminal_status`). Returns `None` when
+/// the envelope is absent or carries no `agentId`.
+struct AsyncAgentSignal<'a> {
+    agent_id: &'a str,
+    status: &'a str,
+}
+
+impl<'a> AsyncAgentSignal<'a> {
+    fn parse(tur: &'a Value) -> Option<Self> {
+        let agent_id = tur.get("agentId").and_then(Value::as_str)?;
+        let status = tur.get("status").and_then(Value::as_str).unwrap_or("");
+        Some(Self { agent_id, status })
+    }
+
+    fn is_async_launched(&self) -> bool {
+        self.status == STATUS_ASYNC_LAUNCHED
+    }
+}
+
 // ── Three-path event dispatcher ──────────────────────────────────────
 
 fn apply_transcript_event(state: &mut SessionState, raw_event: &Value) {
@@ -241,12 +271,18 @@ fn apply_transcript_event(state: &mut SessionState, raw_event: &Value) {
         .and_then(Value::as_str)
         .map(ToString::to_string);
 
+    // Top-level `toolUseResult` envelope on user-message events. CC stamps
+    // it alongside `tool_result` content blocks with structured metadata
+    // — including `agentId`/`status` for async-agent dispatch — so we can
+    // disambiguate `async_launched` (agent still running) from terminal.
+    let tool_use_result = raw_event.get("toolUseResult");
+
     // Path 1: Nested content[] blocks (real Claude Code transcript format)
     // Messages have: { "message": { "role": "assistant", "content": [{...}] } }
     // Or:           { "role": "user", "content": [{...}] }
     if let Some(content_blocks) = extract_content_blocks(raw_event) {
         for block in content_blocks {
-            apply_content_block(state, block, event_ts, message_id.clone());
+            apply_content_block(state, block, event_ts, message_id.clone(), tool_use_result);
         }
         // Defense-in-depth: also check toolUseResult for agent completion signal
         check_tool_use_result_completion(state, raw_event);
@@ -315,6 +351,7 @@ fn apply_content_block(
     block: &Value,
     event_ts: Option<u64>,
     message_id: Option<String>,
+    tool_use_result: Option<&Value>,
 ) {
     let block_type = match block.get("type").and_then(Value::as_str) {
         Some(t) => t,
@@ -402,11 +439,24 @@ fn apply_content_block(
             state.upsert_tool(id, name, target);
         }
         "tool_result" => {
-            if let Some(id) = block.get("tool_use_id").and_then(Value::as_str) {
-                complete_tool_result(state, id, event_ts);
+            let tool_use_id = block.get("tool_use_id").and_then(Value::as_str);
+            let signal = tool_use_result.and_then(AsyncAgentSignal::parse);
+
+            // Async-agent dispatch (status "async_launched") binds the
+            // runtime agentId to the active AgentSummary so we can tail
+            // `<parent>/subagents/agent-<id>.jsonl`; the agent is still
+            // running, so the normal completion path is skipped. Real
+            // completion arrives later via terminal-status toolUseResult
+            // (see `check_tool_use_result_completion`).
+            match (tool_use_id, signal) {
+                (Some(id), Some(s)) if s.is_async_launched() => {
+                    state.bind_agent_id(id, s.agent_id);
+                    state.ensure_sub_agent(s.agent_id.to_string(), event_ts);
+                }
+                (Some(id), _) => complete_tool_result(state, id, event_ts),
+                (None, _) => {}
             }
 
-            // Check for todo data in result
             if let Some(todo) = extract_todo_summary(block) {
                 state.set_todo(Some(todo));
             }
@@ -432,6 +482,7 @@ fn handle_agent_progress(state: &mut SessionState, data: &Value, event_ts: Optio
 
     if is_terminal_status(status) {
         state.remove_agent(&agent_id);
+        state.sub_agents.remove(&agent_id);
         return;
     }
 
@@ -542,6 +593,16 @@ fn dispatch_todo_write(state: &mut SessionState, event: &Value, fallback: Option
 /// Complete a tool_result by resolving agent links: linked agent, pending task, or plain removal.
 fn complete_tool_result(state: &mut SessionState, tool_use_id: &str, event_ts: Option<u64>) {
     state.remove_tool(tool_use_id, event_ts);
+
+    // If the active agent identified by `tool_use_id` carries a runtime
+    // `agent_id`, the sub-agent transcript tail belongs to this agent —
+    // drop it on completion so we don't keep reading a stale file.
+    let bound_agent_id = state
+        .active_agents
+        .iter()
+        .find(|a| a.id == tool_use_id)
+        .and_then(|a| a.agent_id.clone());
+
     if let Some(linked_agent) = state.resolve_task_agent(tool_use_id) {
         state.remove_agent(&linked_agent);
     } else if let Some(pending) = state.drain_pending_task(tool_use_id) {
@@ -556,6 +617,10 @@ fn complete_tool_result(state: &mut SessionState, tool_use_id: &str, event_ts: O
         state.remove_agent(tool_use_id);
     } else {
         state.remove_agent(tool_use_id);
+    }
+
+    if let Some(agent_id) = bound_agent_id {
+        state.sub_agents.remove(&agent_id);
     }
 }
 
@@ -767,14 +832,28 @@ fn handle_event_by_name(
 /// content block processed by Path 1, but provides a fallback if the link-based resolution
 /// in `complete_tool_result()` fails (e.g., ID mismatch). `remove_agent()` is idempotent.
 fn check_tool_use_result_completion(state: &mut SessionState, raw_event: &Value) {
-    if let Some(tur) = raw_event.get("toolUseResult") {
-        if let Some(agent_id) = tur.get("agentId").and_then(Value::as_str) {
-            let status = tur.get("status").and_then(Value::as_str).unwrap_or("");
-            if is_terminal_status(status) {
-                state.remove_agent(agent_id);
-            }
-        }
+    let Some(signal) = raw_event
+        .get("toolUseResult")
+        .and_then(AsyncAgentSignal::parse)
+    else {
+        return;
+    };
+    if !is_terminal_status(signal.status) {
+        return;
     }
+    // Active list keys agents by tool_use_id; the runtime agent_id may
+    // differ. Try tool_use_id resolution first, then fall back to the
+    // runtime id (remove_agent is idempotent).
+    let tool_use_id = state
+        .active_agents
+        .iter()
+        .find(|a| a.agent_id.as_deref() == Some(signal.agent_id))
+        .map(|a| a.id.clone());
+    match tool_use_id {
+        Some(id) => state.remove_agent(&id),
+        None => state.remove_agent(signal.agent_id),
+    }
+    state.sub_agents.remove(signal.agent_id);
 }
 
 fn is_terminal_status(status: &str) -> bool {
@@ -797,7 +876,204 @@ fn snapshot_from_state(state: &SessionState, config: &RenderConfig) -> Transcrip
         tools: state.capped_tools(config.max_tool_lines),
         completed_counts: state.scored_completed_tools(config.max_completed_tools),
         agents: state.agents_for_display(AGENT_SNAPSHOT_CAP),
-        todo: state.todo.clone(),
+        todo: aggregate_todo(state),
+    }
+}
+
+/// Combine the parent session's `state.todo` with any sub-agents' derived
+/// TODO state into a single displayed `TodoSummary`. Three cases:
+/// - Parent has TODO + sub-agents idle → return parent unchanged.
+/// - Parent has TODO + sub-agents busy → return parent (don't pollute the
+///   user's own todo list; sub-agents are surfaced separately on agent
+///   rows by future work).
+/// - Parent idle + sub-agents busy → aggregate counts across sub-agents
+///   and stamp the text with `(N agents)` so the user knows the source.
+fn aggregate_todo(state: &SessionState) -> Option<TodoSummary> {
+    if state.todo.is_some() {
+        return state.todo.clone();
+    }
+    if state.sub_agents.is_empty() {
+        return None;
+    }
+
+    let summaries: Vec<TodoSummary> = state
+        .sub_agents
+        .values()
+        .filter_map(|sub| sub.derived_todo())
+        .collect();
+    if summaries.is_empty() {
+        return None;
+    }
+
+    let mut total = 0usize;
+    let mut completed = 0usize;
+    let mut in_progress_items: Vec<crate::types::TodoInProgressItem> = Vec::new();
+    let mut all_done = true;
+    for summary in &summaries {
+        total += summary.total;
+        completed += summary.completed;
+        in_progress_items.extend(summary.in_progress_items.iter().cloned());
+        if !summary.all_done {
+            all_done = false;
+        }
+    }
+    let pending = total.saturating_sub(completed);
+    in_progress_items.sort_by_key(|item| item.started_at.unwrap_or(u64::MAX));
+
+    let agents = summaries.len();
+    Some(TodoSummary {
+        text: format!("{completed}/{total} done, {pending} pending"),
+        pending,
+        completed,
+        total,
+        in_progress_items,
+        all_done,
+        is_task_api: summaries.iter().any(|s| s.is_task_api),
+        sub_agent_count: Some(agents),
+    })
+}
+
+/// Path: `<parent_dir>/<parent_basename_without_ext>/subagents/agent-<id>.jsonl`.
+/// Returns `None` if the parent path doesn't end in `.jsonl` — defensive
+/// against unexpected schemas without panicking.
+fn sub_agent_transcript_path(parent_transcript: &Path, agent_id: &str) -> Option<PathBuf> {
+    let stem = parent_transcript.file_stem()?.to_str()?;
+    let parent_dir = parent_transcript.parent()?;
+    Some(
+        parent_dir
+            .join(stem)
+            .join("subagents")
+            .join(format!("agent-{agent_id}.jsonl")),
+    )
+}
+
+/// For every entry in `state.sub_agents`, attempt to tail the
+/// corresponding `agent-<id>.jsonl`. Drops the entry on missing file
+/// (e.g. agent finished and CC pruned its transcript) — keeps the cap
+/// honest and prevents stale state from accumulating across sessions.
+fn tail_sub_agent_transcripts(
+    state: &mut SessionState,
+    parent_transcript_path: &str,
+    config: &RenderConfig,
+) {
+    if state.sub_agents.is_empty() {
+        return;
+    }
+    let parent = Path::new(parent_transcript_path);
+    // Mutating the map during iteration requires owning the keys up-front.
+    let agent_ids: Vec<String> = state.sub_agents.keys().cloned().collect();
+    for agent_id in agent_ids {
+        let Some(sub_path) = sub_agent_transcript_path(parent, &agent_id) else {
+            continue;
+        };
+        // `metadata()` returns Err on ENOENT — handles the "file not
+        // materialized yet" case without a separate exists() probe. GC
+        // for completed agents runs in `check_tool_use_result_completion`
+        // / `handle_agent_progress`, not here.
+        let Ok(file_len) = sub_path.metadata().map(|m| m.len()) else {
+            continue;
+        };
+
+        let sub = state
+            .sub_agents
+            .get_mut(&agent_id)
+            .expect("agent_id was just read from sub_agents map");
+
+        if file_len < sub.offset {
+            // File truncated/rotated — restart from 0 and clear derived
+            // TODO state to match the new history.
+            sub.offset = 0;
+            sub.task_items.clear();
+            sub.task_counter = 0;
+            sub.legacy_todo = None;
+        } else if file_len == sub.offset {
+            // No new bytes since last tick — skip the open+seek+read for
+            // the steady-state case (sub-agent idle between events).
+            continue;
+        }
+
+        if let Ok(new_lines) = read_new_lines(&sub_path, sub.offset) {
+            let mut events: Vec<Value> = new_lines
+                .iter()
+                .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+                .collect();
+
+            if config.transcript_window_events > 0 && events.len() > config.transcript_window_events
+            {
+                let keep_from = events.len() - config.transcript_window_events;
+                events.drain(0..keep_from);
+            }
+
+            for event in events {
+                apply_sub_agent_event(sub, &event);
+            }
+        }
+
+        sub.offset = file_len;
+    }
+}
+
+/// Scoped event dispatcher for a single sub-agent transcript. Mirrors the
+/// parent `apply_transcript_event` shape but only routes
+/// TaskCreate/TaskUpdate/TodoWrite/embedded-todos into the
+/// `SubAgentTranscriptState` — every other tool/agent event is ignored so
+/// the sub-agent's own tool activity does not pollute the parent
+/// statusline's tool/agent rows.
+fn apply_sub_agent_event(sub: &mut SubAgentTranscriptState, raw_event: &Value) {
+    let event_ts = raw_event
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .and_then(parse_iso_timestamp);
+    if event_ts.is_some() {
+        sub.last_event_ts = event_ts;
+    }
+
+    let Some(blocks) = extract_content_blocks(raw_event) else {
+        return;
+    };
+    for block in blocks {
+        let Some(block_type) = block.get("type").and_then(Value::as_str) else {
+            continue;
+        };
+        match block_type {
+            "tool_use" => {
+                let name = block.get("name").and_then(Value::as_str).unwrap_or("");
+                match name {
+                    "TaskCreate" => {
+                        let subject = find_string(block, &["subject"])
+                            .or_else(|| find_nested_string(block, &[&["input", "subject"]]));
+                        let active_form = find_string(block, &["activeForm"])
+                            .or_else(|| find_nested_string(block, &[&["input", "activeForm"]]));
+                        if let Some(subject) = subject {
+                            sub.create_task_item(subject, active_form);
+                        }
+                    }
+                    "TaskUpdate" => {
+                        let task_id = find_string(block, &["taskId"])
+                            .or_else(|| find_nested_string(block, &[&["input", "taskId"]]));
+                        if let Some(task_id) = task_id {
+                            let status = find_string(block, &["status"])
+                                .or_else(|| find_nested_string(block, &[&["input", "status"]]))
+                                .unwrap_or_else(|| "pending".to_string());
+                            sub.update_task_item(&task_id, &status);
+                        } else if let Some(todo) = extract_todo_summary(block) {
+                            sub.set_legacy_todo(Some(todo));
+                        }
+                    }
+                    "TodoWrite" => {
+                        let todo = extract_todo_summary(block);
+                        sub.set_legacy_todo(todo);
+                    }
+                    _ => {}
+                }
+            }
+            "tool_result" => {
+                if let Some(todo) = extract_todo_summary(block) {
+                    sub.set_legacy_todo(Some(todo));
+                }
+            }
+            _ => {}
+        }
     }
 }
 

--- a/src/render/activity/agent_groups.rs
+++ b/src/render/activity/agent_groups.rs
@@ -104,6 +104,7 @@ mod tests {
             model: None,
             completed_at: Some(60_000),
             message_id: msg.map(String::from),
+            agent_id: None,
         }
     }
 

--- a/src/render/activity/builder.rs
+++ b/src/render/activity/builder.rs
@@ -656,7 +656,9 @@ fn build_todo_rows(
             &p.secondary,
             color,
         );
-        rows.push(format!("{prefix}{body}{count}"));
+        let agent_suffix =
+            crate::render::fmt::sub_agent_suffix(todo.sub_agent_count, &p.secondary, color);
+        rows.push(format!("{prefix}{body}{count}{agent_suffix}"));
         return rows;
     }
 
@@ -664,7 +666,9 @@ fn build_todo_rows(
     if !todo.text.is_empty() {
         let prefix = colorize(&glyph(mode, ICON_TODO, "TODO:"), p.todo_teal(), color);
         let text = colorize(&todo.text, p.todo_teal(), color);
-        rows.push(format!("{prefix}{text}"));
+        let agent_suffix =
+            crate::render::fmt::sub_agent_suffix(todo.sub_agent_count, &p.secondary, color);
+        rows.push(format!("{prefix}{text}{agent_suffix}"));
     }
 
     rows
@@ -785,6 +789,7 @@ mod tests {
             model: None,
             completed_at: Some(61_000),
             message_id: msg.map(String::from),
+            agent_id: None,
         }
     }
 
@@ -1307,6 +1312,7 @@ mod tests {
                 in_progress_items: vec![],
                 all_done: true,
                 is_task_api: true,
+                sub_agent_count: None,
             }),
             ..Default::default()
         };

--- a/src/render/fmt.rs
+++ b/src/render/fmt.rs
@@ -100,6 +100,19 @@ pub fn format_reset_duration(minutes: u64) -> String {
     }
 }
 
+/// "(N agents)" suffix for a TODO row aggregated from background
+/// sub-agents. Empty string for the user's own TODO. Layouts pass their
+/// preferred secondary-tier palette color so the suffix sits visually
+/// below the primary TODO value.
+pub fn sub_agent_suffix(count: Option<usize>, color_spec: &str, color_enabled: bool) -> String {
+    use crate::render::color::colorize;
+    match count {
+        Some(1) => colorize(" (1 agent)", color_spec, color_enabled),
+        Some(n) if n > 1 => colorize(&format!(" ({n} agents)"), color_spec, color_enabled),
+        _ => String::new(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/render/frames/ledger.rs
+++ b/src/render/frames/ledger.rs
@@ -115,14 +115,22 @@ pub fn render(frame: &RenderFrame, config: &RenderConfig, p: &ThemePalette) -> V
 
     lines.push(top_frame(&frame.line1, config, &ctx));
 
+    // Lazy separator: blank row pushed before each non-empty group after the
+    // first, so no trailing blank can reach `bottom_frame`.
+    let mut groups: Vec<Vec<String>> = Vec::with_capacity(4);
+
+    // G1 ENV
     if shared::config_row_enabled(config) {
         let body = env_row_body(frame, config, p, content_width);
         if !body.is_empty() {
-            lines.push(framed_tag_row("ENV", &body, &ctx));
-            lines.push(blank_row(&ctx));
+            groups.push(vec![framed_tag_row("ENV", &body, &ctx)]);
         }
     }
 
+    // G2 Budget + Quota — CTX/TOK/COST/5h/7d are visually packed (no
+    // blank between Budget and Quota in the legacy output), so we treat
+    // them as a single group.
+    let mut budget_quota: Vec<String> = Vec::with_capacity(5);
     if config.show_context {
         let body = ctx_row_body(
             &frame.line3,
@@ -133,23 +141,21 @@ pub fn render(frame: &RenderFrame, config: &RenderConfig, p: &ThemePalette) -> V
             ctx.color,
         );
         if !body.is_empty() {
-            lines.push(framed_tag_row("CTX", &body, &ctx));
+            budget_quota.push(framed_tag_row("CTX", &body, &ctx));
         }
     }
     if config.show_tokens {
         let body = tok_row_body(&frame.line3, p, ctx.color);
         if !body.is_empty() {
-            lines.push(framed_tag_row("TOK", &body, &ctx));
+            budget_quota.push(framed_tag_row("TOK", &body, &ctx));
         }
     }
     if config.show_cost {
         let body = cost_row_body(&frame.line3, p, ctx.color);
         if !body.is_empty() {
-            lines.push(framed_tag_row("COST", &body, &ctx));
+            budget_quota.push(framed_tag_row("COST", &body, &ctx));
         }
     }
-
-    let mut quota_emitted = false;
     if config.show_quota && frame.quota.has_data() {
         if config.show_quota_five_hour {
             if let Some(body) = quota_row_body(
@@ -159,8 +165,7 @@ pub fn render(frame: &RenderFrame, config: &RenderConfig, p: &ThemePalette) -> V
                 p,
                 ctx.color,
             ) {
-                lines.push(framed_tag_row("5h", &body, &ctx));
-                quota_emitted = true;
+                budget_quota.push(framed_tag_row("5h", &body, &ctx));
             }
         }
         if config.show_quota_seven_day {
@@ -171,35 +176,49 @@ pub fn render(frame: &RenderFrame, config: &RenderConfig, p: &ThemePalette) -> V
                 p,
                 ctx.color,
             ) {
-                lines.push(framed_tag_row("7d", &body, &ctx));
-                quota_emitted = true;
+                budget_quota.push(framed_tag_row("7d", &body, &ctx));
             }
         }
     }
-    if quota_emitted {
-        lines.push(blank_row(&ctx));
+    if !budget_quota.is_empty() {
+        groups.push(budget_quota);
     }
 
+    // G3 Tools
     let tool_rows = build_tool_rows(frame, config, p, content_width, ctx.color);
     if !tool_rows.is_empty() {
+        let mut tools: Vec<String> = Vec::with_capacity(tool_rows.len());
         for (i, body) in tool_rows.iter().enumerate() {
             let tag = if i == 0 { "TOOL" } else { "" };
-            lines.push(framed_tag_row(tag, body, &ctx));
+            tools.push(framed_tag_row(tag, body, &ctx));
         }
-        lines.push(blank_row(&ctx));
+        groups.push(tools);
     }
 
+    // G4 Actors (AGENT rows + TODO — visually packed)
+    let mut actors: Vec<String> = Vec::new();
     if config.show_agents {
         let agent_rows = build_agent_rows(frame, config, p, content_width);
         for (i, body) in agent_rows.iter().enumerate() {
             let tag = if i == 0 { "AGENT" } else { "" };
-            lines.push(framed_tag_row(tag, body, &ctx));
+            actors.push(framed_tag_row(tag, body, &ctx));
         }
     }
     if config.show_todo {
         if let Some(body) = todo_row_body(frame, p, ctx.color) {
-            lines.push(framed_tag_row("TODO", &body, &ctx));
+            actors.push(framed_tag_row("TODO", &body, &ctx));
         }
+    }
+    if !actors.is_empty() {
+        groups.push(actors);
+    }
+
+    let dense = config.pane_ledger_dense;
+    for (i, group) in groups.into_iter().enumerate() {
+        if i > 0 && !dense {
+            lines.push(blank_row(&ctx));
+        }
+        lines.extend(group);
     }
 
     lines.push(bottom_frame(&ctx));

--- a/src/render/frames/ledger.rs
+++ b/src/render/frames/ledger.rs
@@ -710,11 +710,21 @@ fn build_agent_rows(
 
 fn todo_row_body(frame: &RenderFrame, p: &ThemePalette, color: bool) -> Option<String> {
     let todo = frame.todo.as_ref()?;
+    let agent_suffix =
+        crate::render::fmt::sub_agent_suffix(todo.sub_agent_count, &p.structural, color);
     if todo.all_done {
         let s = format!("\u{2713} All complete ({}/{})", todo.completed, todo.total);
-        return Some(colorize(&s, &p.completed_check, color));
+        return Some(format!(
+            "{}{}",
+            colorize(&s, &p.completed_check, color),
+            agent_suffix
+        ));
     }
     let done = todo.completed.max(todo.total.saturating_sub(todo.pending));
     let body = format!("{}/{} done · {} pending", done, todo.total, todo.pending);
-    Some(colorize(&body, p.todo_teal(), color))
+    Some(format!(
+        "{}{}",
+        colorize(&body, p.todo_teal(), color),
+        agent_suffix
+    ))
 }

--- a/src/state/cache.rs
+++ b/src/state/cache.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     providers::{EnvSnapshot, GitSnapshot},
+    state::SubAgentTranscriptState,
     types::{AgentSummary, Line3Metrics, PendingTask, TaskItem, TodoSummary, ToolSummary},
 };
 
@@ -56,6 +57,9 @@ pub struct SessionCache {
     // Sparkline source — last N `(pct, epoch_ms)` samples.
     #[serde(default)]
     pub ctx_history: VecDeque<(u8, u64)>,
+    // Per-sub-agent tail offsets + task state.
+    #[serde(default)]
+    pub sub_agents: HashMap<String, SubAgentTranscriptState>,
     // Env/Git with timestamps
     pub env: Option<CacheEntry<EnvSnapshot>>,
     pub git: Option<CacheEntry<GitSnapshot>>,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -13,8 +13,140 @@ use crate::{
     },
 };
 use cache::{CacheEntry, SessionCache, CACHE_TTL_MS};
+use serde::{Deserialize, Serialize};
 
 const MAX_RECENT_TOOLS_CAP: usize = 10;
+
+/// Maximum number of sub-agent transcripts tailed concurrently. Each adds
+/// one open+seek+read per statusline tick; the cap keeps the worst-case
+/// file-IO bounded under the p95 < 50ms render budget. Drop oldest by
+/// `last_event_ts` on overflow.
+pub const MAX_SUBAGENT_TAILS: usize = 6;
+
+/// Upper bound on `task_items` retained per sub-agent. Pathological agents
+/// doing thousands of TaskCreate calls would otherwise bloat the session
+/// cache file (every entry serializes to disk each tick). On overflow,
+/// drop the lowest-numbered task ids (FIFO oldest-first).
+pub const MAX_SUBAGENT_TASKS: usize = 200;
+
+/// Per-sub-agent transcript state. Each Claude Code agent dispatched via
+/// the Task tool gets its own JSONL transcript at
+/// `<parent_dir>/subagents/agent-<agentId>.jsonl`; this struct holds the
+/// incremental tail state so cc-pulseline can surface TODO progress from
+/// inside the sub-agent. Aggregation happens at snapshot time
+/// (`snapshot_from_state`), not during ingestion — each sub-agent's task
+/// universe stays isolated.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SubAgentTranscriptState {
+    pub offset: u64,
+    #[serde(default)]
+    pub task_items: HashMap<String, TaskItem>,
+    #[serde(default)]
+    pub task_counter: u32,
+    /// Fallback for sub-agents that use the legacy TodoWrite path (not
+    /// TaskCreate/TaskUpdate). Aggregator prefers this when present.
+    #[serde(default)]
+    pub legacy_todo: Option<TodoSummary>,
+    #[serde(default)]
+    pub last_event_ts: Option<u64>,
+}
+
+/// Canonical builder for the Task-API `TodoSummary`. Used by both the
+/// parent session's `rebuild_todo_from_tasks` and each sub-agent's
+/// `derived_todo`; aggregator paths reuse the same fields via direct
+/// construction. Returns `None` when `task_items` is empty so callers
+/// can fall through to other sources (e.g. legacy TodoWrite).
+pub fn build_todo_from_tasks(task_items: &HashMap<String, TaskItem>) -> Option<TodoSummary> {
+    if task_items.is_empty() {
+        return None;
+    }
+    let total = task_items.len();
+    let completed = task_items
+        .values()
+        .filter(|item| item.status == "completed")
+        .count();
+    let pending = total.saturating_sub(completed);
+
+    let mut in_progress_items: Vec<TodoInProgressItem> = task_items
+        .values()
+        .filter(|item| item.status == "in_progress")
+        .map(|item| TodoInProgressItem {
+            text: item
+                .active_form
+                .clone()
+                .unwrap_or_else(|| item.subject.clone()),
+            started_at: item.started_at,
+        })
+        .collect();
+    in_progress_items.sort_by_key(|item| item.started_at.unwrap_or(u64::MAX));
+
+    let all_done = pending == 0 && completed > 0;
+    Some(TodoSummary {
+        text: format!("{completed}/{total} done, {pending} pending"),
+        pending,
+        completed,
+        total,
+        in_progress_items,
+        all_done,
+        is_task_api: true,
+        sub_agent_count: None,
+    })
+}
+
+impl SubAgentTranscriptState {
+    pub fn create_task_item(&mut self, subject: String, active_form: Option<String>) {
+        self.task_counter += 1;
+        let id = self.task_counter.to_string();
+        self.task_items.insert(
+            id,
+            TaskItem {
+                subject,
+                status: "pending".to_string(),
+                active_form,
+                started_at: None,
+            },
+        );
+        // `task_counter` only grows; the oldest still-resident ids are
+        // therefore the smallest numerically. Evict in that order until
+        // the cap is satisfied.
+        while self.task_items.len() > MAX_SUBAGENT_TASKS {
+            let oldest = self
+                .task_items
+                .keys()
+                .filter_map(|k| k.parse::<u32>().ok().map(|n| (n, k.clone())))
+                .min_by_key(|(n, _)| *n)
+                .map(|(_, k)| k);
+            match oldest {
+                Some(k) => {
+                    self.task_items.remove(&k);
+                }
+                None => break,
+            }
+        }
+    }
+
+    /// Mirror of `SessionState::update_task_item` scoped to one sub-agent.
+    pub fn update_task_item(&mut self, task_id: &str, status: &str) {
+        if status == "deleted" {
+            self.task_items.remove(task_id);
+        } else if let Some(item) = self.task_items.get_mut(task_id) {
+            if status == "in_progress" && item.status != "in_progress" {
+                item.started_at = Some(cache::now_epoch_ms());
+            }
+            item.status = status.to_string();
+        }
+    }
+
+    pub fn set_legacy_todo(&mut self, todo: Option<TodoSummary>) {
+        self.legacy_todo = todo;
+    }
+
+    /// Sub-agent TODO from Task API items, falling back to the legacy
+    /// TodoWrite summary when there are no Task items.
+    pub fn derived_todo(&self) -> Option<TodoSummary> {
+        build_todo_from_tasks(&self.task_items).or_else(|| self.legacy_todo.clone())
+    }
+}
 
 /// Maximum number of CTX% samples retained for the ledger sparkline. The
 /// widget draws 12 (6 braille cells × 2 samples each); the surplus lets
@@ -49,6 +181,11 @@ pub struct SessionState {
     /// Timestamps drive the ledger's adaptive 1-minute window + velocity-
     /// based aurora coloring.
     pub ctx_history: VecDeque<(u8, u64)>,
+    /// Per-sub-agent transcript tail state, keyed by runtime `agentId`.
+    /// Populated when the parent transcript surfaces a `toolUseResult` with
+    /// `status == "async_launched"`; pruned when the corresponding agent
+    /// reaches a terminal status. See `MAX_SUBAGENT_TAILS` for the cap.
+    pub sub_agents: HashMap<String, SubAgentTranscriptState>,
 }
 
 impl SessionState {
@@ -72,6 +209,7 @@ impl SessionState {
             self.last_output_token_time_ms = None;
             self.output_speed_toks_per_sec = None;
             self.ctx_history.clear();
+            self.sub_agents.clear();
         }
     }
 
@@ -221,10 +359,10 @@ impl SessionState {
         model: Option<String>,
         message_id: Option<String>,
     ) {
-        let (started_at, existing_model, existing_message_id) =
+        let (started_at, existing_model, existing_message_id, existing_agent_id) =
             if let Some(position) = self.active_agents.iter().position(|agent| agent.id == id) {
                 let old = self.active_agents.remove(position);
-                (old.started_at, old.model, old.message_id)
+                (old.started_at, old.model, old.message_id, old.agent_id)
             } else {
                 let ts = started_at.or_else(|| {
                     Some(
@@ -234,7 +372,7 @@ impl SessionState {
                             .as_millis() as u64,
                     )
                 });
-                (ts, None, None)
+                (ts, None, None, None)
             };
         self.active_agents.push(AgentSummary {
             id,
@@ -244,6 +382,7 @@ impl SessionState {
             model: model.or(existing_model),
             completed_at: None,
             message_id: message_id.or(existing_message_id),
+            agent_id: existing_agent_id,
         });
     }
 
@@ -272,6 +411,37 @@ impl SessionState {
     pub fn discard_active_agent(&mut self, id: &str) {
         if let Some(pos) = self.active_agents.iter().position(|a| a.id == id) {
             self.active_agents.remove(pos);
+        }
+    }
+
+    /// Attach a runtime `agentId` (from CC's async-agent `toolUseResult`)
+    /// to the active agent stored under `tool_use_id`. Idempotent.
+    pub fn bind_agent_id(&mut self, tool_use_id: &str, agent_id: &str) {
+        if let Some(agent) = self.active_agents.iter_mut().find(|a| a.id == tool_use_id) {
+            agent.agent_id = Some(agent_id.to_string());
+        }
+    }
+
+    /// Create or refresh the sub-agent transcript-tail entry for
+    /// `agent_id`, evicting the oldest entry by `last_event_ts` if the
+    /// `MAX_SUBAGENT_TAILS` cap is exceeded.
+    pub fn ensure_sub_agent(&mut self, agent_id: String, event_ts: Option<u64>) {
+        let entry = self.sub_agents.entry(agent_id).or_default();
+        if event_ts.is_some() {
+            entry.last_event_ts = event_ts;
+        }
+        while self.sub_agents.len() > MAX_SUBAGENT_TAILS {
+            let oldest = self
+                .sub_agents
+                .iter()
+                .min_by_key(|(_, s)| s.last_event_ts.unwrap_or(0))
+                .map(|(id, _)| id.clone());
+            match oldest {
+                Some(id) => {
+                    self.sub_agents.remove(&id);
+                }
+                None => break,
+            }
         }
     }
 
@@ -360,44 +530,7 @@ impl SessionState {
     }
 
     fn rebuild_todo_from_tasks(&mut self) {
-        if self.task_items.is_empty() {
-            self.todo = None;
-            return;
-        }
-        let total = self.task_items.len();
-        let completed = self
-            .task_items
-            .values()
-            .filter(|item| item.status == "completed")
-            .count();
-        let pending = total.saturating_sub(completed);
-
-        // Collect in-progress items, sorted by started_at (earliest first)
-        let mut in_progress_items: Vec<TodoInProgressItem> = self
-            .task_items
-            .values()
-            .filter(|item| item.status == "in_progress")
-            .map(|item| TodoInProgressItem {
-                text: item
-                    .active_form
-                    .clone()
-                    .unwrap_or_else(|| item.subject.clone()),
-                started_at: item.started_at,
-            })
-            .collect();
-        in_progress_items.sort_by_key(|item| item.started_at.unwrap_or(u64::MAX));
-
-        let all_done = pending == 0 && completed > 0;
-
-        self.todo = Some(TodoSummary {
-            text: format!("{completed}/{total} done, {pending} pending"),
-            pending,
-            completed,
-            total,
-            in_progress_items,
-            all_done,
-            is_task_api: true,
-        });
+        self.todo = build_todo_from_tasks(&self.task_items);
     }
 
     pub fn capped_tools(&self, max_lines: usize) -> Vec<ToolSummary> {
@@ -459,6 +592,7 @@ impl SessionState {
             history.pop_front();
         }
         self.ctx_history = history;
+        self.sub_agents = cache.sub_agents;
 
         // Env/Git only if within TTL
         if let Some(entry) = cache.env {
@@ -494,6 +628,7 @@ impl SessionState {
             last_output_token_time_ms: self.last_output_token_time_ms,
             output_speed_toks_per_sec: self.output_speed_toks_per_sec,
             ctx_history: self.ctx_history.clone(),
+            sub_agents: self.sub_agents.clone(),
             env: self.cached_env.as_ref().map(|(path, snapshot)| CacheEntry {
                 path: path.clone(),
                 snapshot: snapshot.clone(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -281,6 +281,13 @@ pub struct AgentSummary {
     /// cache files or when CC's JSONL schema drifts.
     #[serde(default)]
     pub message_id: Option<String>,
+    /// Runtime agentId from CC's async-agent `toolUseResult.agentId`.
+    /// `Some` once the parent transcript has emitted the async_launched
+    /// tool_result for this agent; keyed against
+    /// `~/.claude/projects/<encoded-cwd>/<parent>/subagents/agent-<id>.jsonl`
+    /// for sub-agent transcript tailing.
+    #[serde(default)]
+    pub agent_id: Option<String>,
 }
 
 impl AgentSummary {
@@ -352,6 +359,12 @@ pub struct TodoSummary {
     pub all_done: bool,
     #[serde(default)]
     pub is_task_api: bool,
+    /// When the TODO line is aggregated from background sub-agents
+    /// (Task-tool dispatch), this is the number of contributing agents.
+    /// `None` for the user's own TODO. Renderer surfaces it as
+    /// "(N agents)" so the user knows the source.
+    #[serde(default)]
+    pub sub_agent_count: Option<usize>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]

--- a/tests/adaptive_performance.rs
+++ b/tests/adaptive_performance.rs
@@ -225,3 +225,111 @@ fn handles_large_transcript_and_stays_within_render_budget() {
         p95
     );
 }
+
+#[test]
+fn sub_agent_tailing_stays_within_render_budget() {
+    // Parent + 3 active sub-agents (each with their own ~800-event
+    // transcript). Verifies the worst-case `1 + N` file-IO per tick
+    // (where N = active sub-agents) still fits inside the 50ms p95
+    // budget at MAX_SUBAGENT_TAILS-class fanout.
+    let workspace = TempDir::new().expect("temp workspace");
+    let parent = workspace.path().join("parent.jsonl");
+
+    // Three Agent dispatches + their async_launched tool_results.
+    let agents = [
+        ("aaaaaaaaaaaaaaaaa", "toolu_perf_a"),
+        ("bbbbbbbbbbbbbbbbb", "toolu_perf_b"),
+        ("ccccccccccccccccc", "toolu_perf_c"),
+    ];
+    for (agent_id, tuid) in agents {
+        let dispatch = json!({
+            "type": "assistant",
+            "timestamp": "2026-05-16T10:00:00.000Z",
+            "message": {
+                "id": format!("msg_{tuid}"),
+                "role": "assistant",
+                "content": [{
+                    "type": "tool_use",
+                    "id": tuid,
+                    "name": "Agent",
+                    "input": {"description": "perf", "subagent_type": "general-purpose", "prompt": "x"}
+                }]
+            }
+        });
+        append_line(&parent, &dispatch.to_string());
+        let launched = json!({
+            "type": "user",
+            "timestamp": "2026-05-16T10:00:01.000Z",
+            "message": {
+                "role": "user",
+                "content": [{
+                    "tool_use_id": tuid,
+                    "type": "tool_result",
+                    "content": [{"type": "text", "text": "Async agent launched successfully."}]
+                }]
+            },
+            "toolUseResult": {"isAsync": true, "status": "async_launched", "agentId": agent_id}
+        });
+        append_line(&parent, &launched.to_string());
+    }
+
+    // Each sub-agent's transcript: ~800 lines of TaskCreate + a few updates.
+    let parent_stem = parent.file_stem().unwrap().to_str().unwrap();
+    let subagents_dir = parent.parent().unwrap().join(parent_stem).join("subagents");
+    fs::create_dir_all(&subagents_dir).expect("subagents dir");
+    for (agent_id, _) in agents {
+        let sub_path = subagents_dir.join(format!("agent-{agent_id}.jsonl"));
+        for i in 0..800 {
+            let event = json!({
+                "type": "assistant",
+                "isSidechain": true,
+                "agentId": agent_id,
+                "timestamp": "2026-05-16T10:00:02.000Z",
+                "message": {
+                    "id": format!("msg_{agent_id}_{i}"),
+                    "role": "assistant",
+                    "content": [{
+                        "type": "tool_use",
+                        "id": format!("toolu_{agent_id}_{i}"),
+                        "name": "TaskCreate",
+                        "input": {"subject": format!("Step{i}"), "activeForm": format!("Doing Step{i}")}
+                    }]
+                }
+            });
+            append_line(&sub_path, &event.to_string());
+        }
+    }
+
+    let payload = payload_json(&workspace, &parent, "sub-perf");
+    let mut runner = PulseLineRunner::default();
+    let config = RenderConfig {
+        max_tool_lines: 2,
+        max_agent_lines: 3,
+        transcript_window_events: 1000,
+        transcript_poll_throttle_ms: 0,
+        ..RenderConfig::default()
+    };
+
+    // First tick warms the offsets; subsequent ticks read 0 new bytes per
+    // sub-agent — exactly the steady-state case we're protecting.
+    let _ = runner
+        .run_from_str(&payload, config.clone())
+        .expect("first render");
+
+    let mut durations = Vec::with_capacity(120);
+    for _ in 0..120 {
+        let start = Instant::now();
+        let _ = runner
+            .run_from_str(&payload, config.clone())
+            .expect("render should succeed");
+        durations.push(start.elapsed());
+    }
+    durations.sort();
+    let idx = ((durations.len() as f64) * 0.95).floor() as usize;
+    let p95 = durations[idx.min(durations.len() - 1)];
+    assert!(
+        p95 < Duration::from_millis(50),
+        "p95 with sub-agent tailing {:?} exceeded 50ms budget",
+        p95
+    );
+}

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -73,7 +73,7 @@ fn version_flag_shows_version() {
         stdout.contains("cc-pulseline"),
         "should contain binary name"
     );
-    assert!(stdout.contains("1.1.4"), "should contain version number");
+    assert!(stdout.contains("1.1.5"), "should contain version number");
 }
 
 #[test]
@@ -86,7 +86,7 @@ fn short_version_flag_works() {
     assert!(output.status.success(), "should exit 0");
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(
-        stdout.contains("cc-pulseline 1.1.4"),
+        stdout.contains("cc-pulseline 1.1.5"),
         "should show name and version"
     );
 }

--- a/tests/display_axes.rs
+++ b/tests/display_axes.rs
@@ -39,6 +39,7 @@ fn frame_with_agent_and_quota() -> RenderFrame {
         model: None,
         completed_at: None,
         message_id: None,
+        agent_id: None,
     });
     f.quota = QuotaMetrics {
         five_hour_pct: Some(75.0),
@@ -350,6 +351,7 @@ fn console_with_many_agents_no_overflow_and_descriptions_visible() {
         model: Some("haiku".to_string()),
         completed_at: None,
         message_id: Some("m1".to_string()),
+        agent_id: None,
     });
     f.agents.push(AgentSummary {
         id: "p2".to_string(),
@@ -359,6 +361,7 @@ fn console_with_many_agents_no_overflow_and_descriptions_visible() {
         model: Some("haiku".to_string()),
         completed_at: None,
         message_id: Some("m1".to_string()),
+        agent_id: None,
     });
     f.agents.push(AgentSummary {
         id: "s1".to_string(),
@@ -368,6 +371,7 @@ fn console_with_many_agents_no_overflow_and_descriptions_visible() {
         model: None,
         completed_at: None,
         message_id: Some("m2".to_string()),
+        agent_id: None,
     });
     let mut cfg = cfg_for(LayoutStyle::Console, true, 130);
     cfg.max_agent_lines = 3;
@@ -495,6 +499,7 @@ fn console_agents_wrap_to_multiple_rows_when_overflowing_one() {
             model: None,
             completed_at: None,
             message_id: Some(format!("m{i}")),
+            agent_id: None,
         });
     }
     let mut cfg = cfg_for(LayoutStyle::Console, true, 130);
@@ -538,6 +543,7 @@ fn console_agents_visual_name_only_drops_description_and_model() {
         model: Some("haiku".to_string()),
         completed_at: None,
         message_id: None,
+        agent_id: None,
     });
     let mut cfg = cfg_for(LayoutStyle::Console, true, 130);
     cfg.agents_visual = "name".to_string();
@@ -566,6 +572,7 @@ fn console_agents_visual_name_and_model_shows_model_tag_no_description() {
         model: Some("haiku".to_string()),
         completed_at: None,
         message_id: None,
+        agent_id: None,
     });
     let mut cfg = cfg_for(LayoutStyle::Console, true, 130);
     cfg.agents_visual = "name+model".to_string();

--- a/tests/ledger_layout.rs
+++ b/tests/ledger_layout.rs
@@ -560,3 +560,122 @@ fn ledger_all_complete_celebration_line() {
     assert!(blob.contains("All complete"), "celebration line: {blob}");
     assert!(blob.contains("3/3"), "count fraction: {blob}");
 }
+
+/// A row consisting only of the frame bars and inner spaces — the visual
+/// signature of `blank_row()` when color is disabled.
+fn is_blank_inner_row(line: &str) -> bool {
+    // Strip the outer frame bars and check the interior is whitespace-only.
+    let stripped = line.trim_start_matches('│').trim_end_matches('│');
+    !stripped.is_empty() && stripped.chars().all(|c| c == ' ')
+}
+
+#[test]
+fn ledger_no_trailing_blank_when_tools_last() {
+    // Invariant: when TOOL is the last non-empty group, no blank row may sit
+    // between it and `bottom_frame`.
+    let mut f = frame_basic();
+    f.tools = vec![ToolSummary {
+        id: "1".to_string(),
+        name: "Read".to_string(),
+        target: Some("src/lib.rs".to_string()),
+    }];
+    f.completed_tools = vec![CompletedToolCount {
+        name: "Read".to_string(),
+        count: 3,
+        last_completed_at: None,
+    }];
+    let mut c = cfg(140);
+    c.show_agents = false;
+    c.show_todo = false;
+    let lines = render_frame(&f, &c);
+
+    assert!(lines.last().unwrap().starts_with('╰'), "bottom frame last");
+    let above_bottom = &lines[lines.len() - 2];
+    assert!(
+        !is_blank_inner_row(above_bottom),
+        "row above bottom frame must NOT be a blank inner row: {above_bottom:?}"
+    );
+    // Sanity check: TOOL group did render.
+    let blob = lines.join("\n");
+    assert!(blob.contains("TOOL"), "TOOL group should render: {blob}");
+}
+
+#[test]
+fn ledger_dense_drops_all_inter_group_blanks() {
+    // dense=true → zero blank rows between groups. Every interior row must
+    // carry a TAG label or content; only the top/bottom frame chrome lines
+    // are exempt.
+    let mut f = frame_basic();
+    f.tools = vec![ToolSummary {
+        id: "1".to_string(),
+        name: "Read".to_string(),
+        target: Some("src/lib.rs".to_string()),
+    }];
+    f.agents.push(AgentSummary {
+        id: "a1".to_string(),
+        description: "Dense rhythm check".to_string(),
+        agent_type: Some("Explore".to_string()),
+        started_at: None,
+        model: None,
+        completed_at: None,
+        message_id: None,
+        agent_id: None,
+    });
+    let mut c = cfg(140);
+    c.pane_ledger_dense = true;
+    let lines = render_frame(&f, &c);
+
+    // Skip top + bottom frame lines; the interior must contain no blank rows.
+    for line in &lines[1..lines.len() - 1] {
+        assert!(
+            !is_blank_inner_row(line),
+            "dense ledger must have no blank inner row: {line:?}"
+        );
+    }
+    // Sanity: groups still rendered.
+    let blob = lines.join("\n");
+    assert!(
+        blob.contains("ENV") || blob.contains("CTX"),
+        "G1/G2: {blob}"
+    );
+    assert!(blob.contains("TOOL"), "tools group: {blob}");
+    assert!(blob.contains("AGENT"), "actors group: {blob}");
+}
+
+#[test]
+fn ledger_dense_false_preserves_legacy_spacing() {
+    // dense=false (default) reproduces the legacy blank-row positions:
+    // exactly one blank between each pair of present groups, and no
+    // trailing blank above the bottom frame.
+    let mut f = frame_basic();
+    f.tools = vec![ToolSummary {
+        id: "1".to_string(),
+        name: "Read".to_string(),
+        target: Some("src/lib.rs".to_string()),
+    }];
+    f.agents.push(AgentSummary {
+        id: "a1".to_string(),
+        description: "Legacy rhythm check".to_string(),
+        agent_type: Some("Explore".to_string()),
+        started_at: None,
+        model: None,
+        completed_at: None,
+        message_id: None,
+        agent_id: None,
+    });
+    let lines = render_frame(&f, &cfg(140));
+
+    // Groups present: G1 ENV (default-on), G2 Budget (CTX/TOK/COST),
+    // G3 Tools, G4 Actors → 3 inter-group separators.
+    let blank_count = lines.iter().filter(|l| is_blank_inner_row(l)).count();
+    assert_eq!(
+        blank_count, 3,
+        "expected 3 inter-group blank rows in legacy mode, got {blank_count}: {lines:?}"
+    );
+    // No trailing blank above bottom frame.
+    let above_bottom = &lines[lines.len() - 2];
+    assert!(
+        !is_blank_inner_row(above_bottom),
+        "row above bottom frame must NOT be blank: {above_bottom:?}"
+    );
+}

--- a/tests/ledger_layout.rs
+++ b/tests/ledger_layout.rs
@@ -197,6 +197,7 @@ fn ledger_renders_agent_block() {
         model: Some("haiku".to_string()),
         completed_at: None,
         message_id: None,
+        agent_id: None,
     });
     let lines = render_frame(&f, &cfg(140));
     let blob = lines.join("\n");
@@ -220,6 +221,7 @@ fn ledger_completed_single_agent_renders_done_check() {
         model: Some("haiku".to_string()),
         completed_at: Some(2000),
         message_id: None,
+        agent_id: None,
     });
     let lines = render_frame(&f, &cfg(140));
     let blob = lines.join("\n");
@@ -244,6 +246,7 @@ fn ledger_respects_agents_visual_name_only() {
         model: Some("haiku".to_string()),
         completed_at: None,
         message_id: None,
+        agent_id: None,
     });
     let mut c = cfg(140);
     c.agents_visual = "name".to_string();
@@ -281,7 +284,8 @@ fn ledger_keeps_newest_active_under_cap() {
             started_at: None,
             model: None,
             completed_at: None,
-            message_id: Some(format!("msg_{id}")), // unique → stays Single
+            message_id: Some(format!("msg_{id}")), // unique → stays Single,
+            agent_id: None,
         });
     }
     let mut c = cfg(140);
@@ -549,6 +553,7 @@ fn ledger_all_complete_celebration_line() {
         in_progress_items: Vec::new(),
         all_done: true,
         is_task_api: false,
+        sub_agent_count: None,
     });
     let lines = render_frame(&f, &cfg(140));
     let blob = lines.join("\n");

--- a/tests/sub_agent_transcripts.rs
+++ b/tests/sub_agent_transcripts.rs
@@ -1,0 +1,337 @@
+//! Sub-agent transcript tailing.
+//!
+//! Verifies that when the parent transcript dispatches an Agent (Task tool)
+//! and CC's `toolUseResult` carries `status: "async_launched"` + an
+//! `agentId`, cc-pulseline tails
+//! `<parent>/subagents/agent-<id>.jsonl` and aggregates the sub-agent's
+//! TODO state into the rendered statusline.
+
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+    path::Path,
+};
+
+use cc_pulseline::{config::RenderConfig, PulseLineRunner};
+use serde_json::json;
+use tempfile::TempDir;
+
+fn append_line(path: &Path, line: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("parent dir should be creatable");
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .expect("transcript file should open");
+    writeln!(file, "{line}").expect("line should append");
+}
+
+fn payload_json(workspace: &TempDir, transcript_path: &Path, session_id: &str) -> String {
+    json!({
+        "session_id": session_id,
+        "cwd": workspace.path(),
+        "workspace": {"current_dir": workspace.path()},
+        "model": {"display_name": "Opus"},
+        "output_style": {"name": "concise"},
+        "version": "2.2.0",
+        "transcript_path": transcript_path,
+        "cost": {"total_cost_usd": 1.0, "total_duration_ms": 60000}
+    })
+    .to_string()
+}
+
+fn agent_dispatch_event(tool_use_id: &str, description: &str) -> String {
+    json!({
+        "type": "assistant",
+        "timestamp": "2026-05-16T10:00:00.000Z",
+        "message": {
+            "id": "msg_test1",
+            "role": "assistant",
+            "content": [{
+                "type": "tool_use",
+                "id": tool_use_id,
+                "name": "Agent",
+                "input": {
+                    "description": description,
+                    "subagent_type": "general-purpose",
+                    "prompt": "Do some work."
+                }
+            }]
+        }
+    })
+    .to_string()
+}
+
+fn async_launched_event(tool_use_id: &str, agent_id: &str) -> String {
+    json!({
+        "type": "user",
+        "timestamp": "2026-05-16T10:00:01.000Z",
+        "message": {
+            "role": "user",
+            "content": [{
+                "tool_use_id": tool_use_id,
+                "type": "tool_result",
+                "content": [{"type": "text", "text": "Async agent launched successfully."}]
+            }]
+        },
+        "toolUseResult": {
+            "isAsync": true,
+            "status": "async_launched",
+            "agentId": agent_id
+        }
+    })
+    .to_string()
+}
+
+fn agent_completed_event(tool_use_id: &str, agent_id: &str) -> String {
+    json!({
+        "type": "user",
+        "timestamp": "2026-05-16T10:05:00.000Z",
+        "message": {
+            "role": "user",
+            "content": [{
+                "tool_use_id": tool_use_id,
+                "type": "tool_result",
+                "content": [{"type": "text", "text": "Agent completed."}]
+            }]
+        },
+        "toolUseResult": {
+            "isAsync": true,
+            "status": "completed",
+            "agentId": agent_id
+        }
+    })
+    .to_string()
+}
+
+fn task_create_event(agent_id: &str, subject: &str, active_form: &str) -> String {
+    json!({
+        "type": "assistant",
+        "isSidechain": true,
+        "agentId": agent_id,
+        "timestamp": "2026-05-16T10:00:02.000Z",
+        "message": {
+            "id": "msg_sub1",
+            "role": "assistant",
+            "content": [{
+                "type": "tool_use",
+                "id": format!("toolu_sub_{agent_id}_{subject}"),
+                "name": "TaskCreate",
+                "input": {"subject": subject, "activeForm": active_form}
+            }]
+        }
+    })
+    .to_string()
+}
+
+fn sub_agent_path(parent_transcript: &Path, agent_id: &str) -> std::path::PathBuf {
+    let stem = parent_transcript
+        .file_stem()
+        .expect("parent has stem")
+        .to_str()
+        .expect("stem utf8");
+    parent_transcript
+        .parent()
+        .expect("parent dir")
+        .join(stem)
+        .join("subagents")
+        .join(format!("agent-{agent_id}.jsonl"))
+}
+
+#[test]
+fn surfaces_todo_from_a_single_sub_agent() {
+    let workspace = TempDir::new().expect("temp workspace");
+    let parent = workspace.path().join("parent.jsonl");
+    let agent_id = "a1234567890abcdef";
+    let tool_use_id = "toolu_async_one";
+
+    append_line(&parent, &agent_dispatch_event(tool_use_id, "Investigate"));
+    append_line(&parent, &async_launched_event(tool_use_id, agent_id));
+
+    let sub_path = sub_agent_path(&parent, agent_id);
+    append_line(
+        &sub_path,
+        &task_create_event(agent_id, "Step1", "Doing step 1"),
+    );
+    append_line(
+        &sub_path,
+        &task_create_event(agent_id, "Step2", "Doing step 2"),
+    );
+    append_line(
+        &sub_path,
+        &task_create_event(agent_id, "Step3", "Doing step 3"),
+    );
+
+    let mut runner = PulseLineRunner::default();
+    let config = RenderConfig {
+        transcript_poll_throttle_ms: 0,
+        ..RenderConfig::default()
+    };
+    let lines = runner
+        .run_from_str(&payload_json(&workspace, &parent, "sub-one"), config)
+        .expect("render should succeed");
+    let joined = lines.join("\n");
+
+    assert!(
+        joined.contains("TODO"),
+        "expected a TODO line surfacing sub-agent task counts: {joined}"
+    );
+    assert!(
+        joined.contains("3 tasks") && joined.contains("(0/3)"),
+        "expected aggregated 0/3 from sub-agent's TaskCreate calls: {joined}"
+    );
+    assert!(
+        joined.contains("(1 agent)"),
+        "TODO line should annotate sub-agent count: {joined}"
+    );
+}
+
+#[test]
+fn drops_sub_agent_state_when_agent_completes() {
+    let workspace = TempDir::new().expect("temp workspace");
+    let parent = workspace.path().join("parent.jsonl");
+    let agent_id = "a2222222222222222";
+    let tool_use_id = "toolu_async_two";
+
+    append_line(&parent, &agent_dispatch_event(tool_use_id, "Sweep"));
+    append_line(&parent, &async_launched_event(tool_use_id, agent_id));
+    let sub_path = sub_agent_path(&parent, agent_id);
+    append_line(
+        &sub_path,
+        &task_create_event(agent_id, "OnlyStep", "Doing OnlyStep"),
+    );
+
+    let mut runner = PulseLineRunner::default();
+    let config = RenderConfig {
+        transcript_poll_throttle_ms: 0,
+        ..RenderConfig::default()
+    };
+
+    // First tick: sub-agent TODO surfaces.
+    let lines = runner
+        .run_from_str(&payload_json(&workspace, &parent, "sub-gc"), config.clone())
+        .expect("render should succeed");
+    let joined_first = lines.join("\n");
+    assert!(
+        joined_first.contains("(0/1)") && joined_first.contains("(1 agent)"),
+        "expected sub-agent's 0/1 initially: {lines:?}"
+    );
+
+    // Parent gets the terminal toolUseResult → sub-agent state should be GC'd.
+    append_line(&parent, &agent_completed_event(tool_use_id, agent_id));
+    let lines = runner
+        .run_from_str(&payload_json(&workspace, &parent, "sub-gc"), config)
+        .expect("render should succeed");
+    let joined = lines.join("\n");
+    assert!(
+        !joined.contains("TODO"),
+        "TODO line should disappear once the only sub-agent completes: {joined}"
+    );
+}
+
+#[test]
+fn aggregates_todo_across_two_concurrent_sub_agents() {
+    let workspace = TempDir::new().expect("temp workspace");
+    let parent = workspace.path().join("parent.jsonl");
+
+    let agent_a = "aaaaaaaaaaaaaaaaa";
+    let agent_b = "bbbbbbbbbbbbbbbbb";
+    let tuid_a = "toolu_async_a";
+    let tuid_b = "toolu_async_b";
+
+    append_line(&parent, &agent_dispatch_event(tuid_a, "Branch A"));
+    append_line(&parent, &async_launched_event(tuid_a, agent_a));
+    append_line(&parent, &agent_dispatch_event(tuid_b, "Branch B"));
+    append_line(&parent, &async_launched_event(tuid_b, agent_b));
+
+    let sub_a = sub_agent_path(&parent, agent_a);
+    append_line(&sub_a, &task_create_event(agent_a, "A1", "Doing A1"));
+    append_line(&sub_a, &task_create_event(agent_a, "A2", "Doing A2"));
+
+    let sub_b = sub_agent_path(&parent, agent_b);
+    append_line(&sub_b, &task_create_event(agent_b, "B1", "Doing B1"));
+    append_line(&sub_b, &task_create_event(agent_b, "B2", "Doing B2"));
+    append_line(&sub_b, &task_create_event(agent_b, "B3", "Doing B3"));
+
+    let mut runner = PulseLineRunner::default();
+    let config = RenderConfig {
+        transcript_poll_throttle_ms: 0,
+        ..RenderConfig::default()
+    };
+    let lines = runner
+        .run_from_str(&payload_json(&workspace, &parent, "sub-agg"), config)
+        .expect("render should succeed");
+    let joined = lines.join("\n");
+
+    assert!(
+        joined.contains("5 tasks") && joined.contains("(0/5)"),
+        "expected aggregated 0/5 across two sub-agents (2 + 3 tasks): {joined}"
+    );
+    assert!(
+        joined.contains("(2 agents)"),
+        "TODO line should annotate two sub-agents: {joined}"
+    );
+}
+
+#[test]
+fn parent_owned_todo_wins_over_sub_agent_todo() {
+    // When the parent session has its own TODO in flight, aggregation
+    // should NOT replace it with sub-agent aggregate — the user's own
+    // TodoWrite/TaskCreate stays authoritative.
+    let workspace = TempDir::new().expect("temp workspace");
+    let parent = workspace.path().join("parent.jsonl");
+    let agent_id = "a3333333333333333";
+    let tuid = "toolu_async_three";
+
+    // Parent does its own TaskCreate first.
+    let parent_task = json!({
+        "type": "assistant",
+        "timestamp": "2026-05-16T09:59:00.000Z",
+        "message": {
+            "id": "msg_parent",
+            "role": "assistant",
+            "content": [{
+                "type": "tool_use",
+                "id": "toolu_parent_task",
+                "name": "TaskCreate",
+                "input": {"subject": "ParentTask", "activeForm": "Doing ParentTask"}
+            }]
+        }
+    });
+    append_line(&parent, &parent_task.to_string());
+
+    // Then dispatches a sub-agent with its own tasks.
+    append_line(&parent, &agent_dispatch_event(tuid, "Sub work"));
+    append_line(&parent, &async_launched_event(tuid, agent_id));
+    let sub_path = sub_agent_path(&parent, agent_id);
+    append_line(
+        &sub_path,
+        &task_create_event(agent_id, "SubStep1", "Doing SubStep1"),
+    );
+    append_line(
+        &sub_path,
+        &task_create_event(agent_id, "SubStep2", "Doing SubStep2"),
+    );
+
+    let mut runner = PulseLineRunner::default();
+    let config = RenderConfig {
+        transcript_poll_throttle_ms: 0,
+        ..RenderConfig::default()
+    };
+    let lines = runner
+        .run_from_str(&payload_json(&workspace, &parent, "sub-precedence"), config)
+        .expect("render should succeed");
+    let joined = lines.join("\n");
+
+    // Parent's "1 tasks (0/1)" should appear — NOT the aggregated 0/3.
+    assert!(
+        joined.contains("1 tasks") && joined.contains("(0/1)"),
+        "parent's own TODO should win when present: {joined}"
+    );
+    assert!(
+        !joined.contains("(1 agent)") && !joined.contains("(2 agents)"),
+        "parent-owned TODO should not be annotated with sub-agent count: {joined}"
+    );
+}


### PR DESCRIPTION
## Summary

- **Sub-agent TODO tailing** — TODO row now surfaces in-progress state from dispatched sub-agent transcripts; TOOL/AGENT/TODO counts aggregate across the lead session and active sub-agents.
- **Ledger lazy group separators** — `render()` builds groups into `Vec<Vec<String>>` and inserts blank rows lazily, so no trailing blank can reach `bottom_frame` regardless of which groups are populated. Fixes the stray blank above the bottom frame when TOOL was the last non-empty group.
- **`[layout] ledger_dense`** (default `false`) — compact rhythm toggle that drops every inter-group blank in the ledger layout.
- **Release 1.1.5** — version bumped across 6 sites (`Cargo.{toml,lock}`, `.claude-plugin/{plugin,marketplace}.json`, `README.md` CLI banner, `tests/cli_flags.rs` version assertions). CHANGELOG updated.

See `CHANGELOG.md` for full notes.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — 0 warnings
- [x] `cargo test` — all green (207 unit + ~30 integration binaries, includes 3 new ledger spacing tests + `sub_agent_transcripts.rs`)
- [x] `cargo build --release` + `--version` smoke → `cc-pulseline 1.1.5`
- [x] Render smoke with minimal stdin payload produces 5 ANSI lines with no trailing blank above bottom frame
- [ ] Manual: verify ledger output with sub-agent dispatched in a live CC session
- [ ] Manual: toggle `ledger_dense = true` in `.claude/pulseline.toml` and confirm inter-group blanks are dropped