### PR TITLE
ci: bump actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --verbose
@@ -26,7 +26,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -37,7 +37,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -47,7 +47,7 @@ jobs:
     name: MSRV (1.85)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.85
       - uses: Swatinem/rust-cache@v2
       - run: cargo check

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
             target: x86_64-pc-windows-msvc
             use-cross: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -87,28 +87,28 @@ jobs:
 
       - name: Upload artifact (unix)
         if: runner.os != 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.BINARY_NAME }}-${{ matrix.platform }}
           path: ${{ env.BINARY_NAME }}-${{ matrix.platform }}.tar.gz
 
       - name: Upload artifact (windows)
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.BINARY_NAME }}-${{ matrix.platform }}
           path: ${{ env.BINARY_NAME }}-${{ matrix.platform }}.zip
 
       - name: Upload raw binary (unix)
         if: runner.os != 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: binary-${{ matrix.platform }}
           path: target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}
 
       - name: Upload raw binary (windows)
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: binary-${{ matrix.platform }}
           path: target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}.exe
@@ -118,9 +118,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
 
@@ -149,13 +149,13 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
 
@@ -196,7 +196,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
 


### PR DESCRIPTION
## Why

The v1.2.0 Release workflow logged GitHub's deprecation warning: `actions/checkout@v4`, `actions/download-artifact@v4`, and `actions/setup-node@v4` run on Node.js 20. **Runners force Node 24 by default starting 2026-06-16**, and Node 20 is removed from runners on 2026-09-16.

## What

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-node | v4 | v6 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |

All four bumped to their current major (Node 24 runtime). Breaking-change notes reviewed against our usage:

- **download-artifact v5** breaking change only affects *single-artifact-by-ID* downloads — release.yml downloads all artifacts into `path:` subdirectories, which is unchanged through v8.
- **download-artifact v8**: ESM migration (transparent to callers); hash mismatches now error by default (a safety win for release assets).
- **upload-artifact v7**: new `archive: false` is opt-in; our `name`+`path` usage is unchanged. v7 upload ↔ v8 download are the matched pair.
- **checkout v6**: credentials persist to a separate file — transparent for our usage.

Unchanged on purpose: `dtolnay/rust-toolchain`, `Swatinem/rust-cache@v2`, `softprops/action-gh-release@v2`, `anthropics/claude-code-action@v1` (floating tags / not named in the warning).

## Verification caveat

PR CI exercises `ci.yml` (checkout v6) but **release.yml only runs on tag push** — the artifact + setup-node bumps get their first real run at the next release. Usage is the most basic documented pattern for all three, so risk is low.