### PR TITLE
fix(test): release-aware p95 budget + CI perf gate on release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,20 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --verbose
 
+  perf:
+    name: Perf budget (release)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # The p95 render-latency budget is a production (release) SLA; the
+      # debug build measured by the matrix job above is ~3x slower and
+      # unrepresentative (see tests/adaptive_performance.rs::p95_budget).
+      # Run the perf tests in release so the strict 50ms budget is enforced
+      # against the shipped artifact, where it has ~50x headroom (no flake).
+      - run: cargo test --release --test adaptive_performance
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/tests/adaptive_performance.rs
+++ b/tests/adaptive_performance.rs
@@ -8,6 +8,16 @@ use cc_pulseline::{config::RenderConfig, render::color::visible_width, PulseLine
 use serde_json::json;
 use tempfile::TempDir;
 
+/// p95 render-latency budget. The shipped binary is a release build; debug
+/// is ~3× slower and GitHub CI runners are highly variable, so the strict
+/// 50ms budget is enforced only where it's meaningful (release). Debug keeps
+/// a loose sanity ceiling that still catches gross regressions without
+/// flaking on a loaded runner. Run `cargo test --release` to exercise the
+/// real budget.
+fn p95_budget() -> Duration {
+    Duration::from_millis(if cfg!(debug_assertions) { 250 } else { 50 })
+}
+
 fn append_line(path: &std::path::Path, line: &str) {
     let mut file = OpenOptions::new()
         .create(true)
@@ -220,9 +230,9 @@ fn handles_large_transcript_and_stays_within_render_budget() {
     let p95 = durations[idx.min(durations.len() - 1)];
 
     assert!(
-        p95 < Duration::from_millis(50),
-        "p95 render latency {:?} exceeded 50ms budget",
-        p95
+        p95 < p95_budget(),
+        "p95 render latency {p95:?} exceeded {:?} budget",
+        p95_budget()
     );
 }
 
@@ -328,8 +338,8 @@ fn sub_agent_tailing_stays_within_render_budget() {
     let idx = ((durations.len() as f64) * 0.95).floor() as usize;
     let p95 = durations[idx.min(durations.len() - 1)];
     assert!(
-        p95 < Duration::from_millis(50),
-        "p95 with sub-agent tailing {:?} exceeded 50ms budget",
-        p95
+        p95 < p95_budget(),
+        "p95 with sub-agent tailing {p95:?} exceeded {:?} budget",
+        p95_budget()
     );
 }


### PR DESCRIPTION
## Problem

The render-latency budget tests in `tests/adaptive_performance.rs` assert a
**50ms wall-clock p95 on a debug build**. That is a category error: the 50ms
figure is a *production* SLA (`performance.md` — the statusline hook calls the
**release** binary, p95 < 50ms), but `cargo test` builds **debug** (no opt,
overflow checks, no inlining → 3–10× slower). The debug number tracks runner
load, not production latency.

It surfaced on the **post-merge `main` CI** for #22 — `Test (ubuntu-latest)`
at p95 **112 / 119ms** — while the same commit **passed CI on the PR branch**,
**passed locally** (5/5, ~0.6s), and the **release publish succeeded**. It
"passed" historically only because machines were fast enough that even the
slow debug build squeaked under 50ms — luck, not design.

## Fix (two parts — the second is the important one)

1. **Env-aware budget.** A `p95_budget()` helper enforces the strict **50ms in
   release** (where it's meaningful) and a loose **250ms sanity ceiling in
   debug** (catches gross regressions without flaking on a loaded runner).

   ```rust
   fn p95_budget() -> Duration {
       Duration::from_millis(if cfg!(debug_assertions) { 250 } else { 50 })
   }
   ```

2. **CI perf gate on a release build.** Part 1 alone would mean the strict
   budget is enforced *nowhere* in CI (the matrix job runs `cargo test` =
   debug = 250ms). So add a dedicated `perf` job running
   `cargo test --release --test adaptive_performance` — the production budget
   is now actually gated, against the shipped artifact, where it has ~50×
   headroom (release: 4 tests incl. two 120-iteration loops in **0.18s**), so
   it won't flake.

Net: debug `cargo test` stops flaking; the real 50ms budget is enforced on the
right artifact in a deterministic single-OS release job.

## Test plan
- `cargo test --release --test adaptive_performance` → **4/4 in 0.18s** (real 50ms budget — no regression)
- `cargo test --test adaptive_performance` (debug) → **4/4** (loose ceiling)
- `cargo fmt --check`, `cargo clippy --tests -- -D warnings` → clean
- `ci.yml` YAML validated; new job: `Perf budget (release)`

No production code changed — test + CI reliability only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)